### PR TITLE
Germplasm Searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,9 @@ This module provides custom search functionality for KnowPulse through use of th
 
 The following searches are provided:
  - Genetic Marker: `search/markers`
+ - Germplasm: `search/germplasm/all`
+ - Breeding Crosses: `search/germplasm/crosses`
+ - Registered Varieties: `search/germplasm/varieties`
+ - RILs: `search/germplasm/RILs`
 
 Many of the searches cache options. To update the option cache run `drush php-eval "kp_searches_cache_options();"`

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -4,7 +4,7 @@
 
 /* - Ensure all select boxes are the same length. */
 #chado-custom-search-form .form-item select {
-  width: 300px;
+  width: 450px;
 }
 
 /* - Make the filter element help italicized. */
@@ -30,4 +30,50 @@
 }
 .seq-range-element input#edit-start-backbone {
   width: 200px;
+}
+
+/**
+ * Germplasm Search.
+ */
+
+/*  - Crop            */
+#chado-custom-search-form .crop {
+  width: 80px;
+  display: inline-block;
+  margin-top: 5px;
+  margin-right: 15px;
+}
+#chado-custom-search-form .crop-title {
+  width: 80px;
+  text-align: center;
+}
+#chado-custom-search-form .crop-img a.active img {
+  margin: 0;
+  border: 1px solid green;
+}
+#chado-custom-search-form .crop-img a.inactive img {
+  opacity: 0.3;
+  filter: alpha(opacity=30); /* msie */
+  border: 1px solid #d0d0d0;
+}
+#chado-custom-search-form .crop a.inactive  {
+  color: #B0B0B0;
+}
+
+/*  - Scientific Name */
+#chado-custom-search-form .scientific-name-element .form-item label {
+  display: none;
+}
+#chado-custom-search-form .scientific-name-element .form-item .description {
+  display: none;
+}
+#chado-custom-search-form .scientific-name-element .form-item {
+  display: inline-block;
+  margin-bottom: 2px;
+}
+#chado-custom-search-form .scientific-name-element select {
+  width: 175px;
+}
+#chado-custom-search-form .scientific-name-element select#edit-species {
+  width: 275px;
 }

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -33,7 +33,7 @@
 }
 
 /**
- * Germplasm Search.
+ * Germplasm Searches.
  */
 
 /*  - Crop            */
@@ -76,4 +76,19 @@
 }
 #chado-custom-search-form .scientific-name-element select#edit-species {
   width: 275px;
+}
+
+/*  - Crossing Block   */
+#chado-custom-search-form .crossingblock-element .form-item label {
+  display: none;
+}
+#chado-custom-search-form .crossingblock-element .form-item .description {
+  display: none;
+}
+#chado-custom-search-form .crossingblock-element .form-item {
+  display: inline-block;
+  margin-bottom: 2px;
+}
+#chado-custom-search-form .crossingblock-element select {
+  width: 225px;
 }

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -7,6 +7,10 @@
   width: 450px;
 }
 
+/* - Ensure all textfields match the select boxes in length. */
+#chado-custom-search-form .form-item input {
+  width: 440px;
+}
 /* - Make the filter element help italicized. */
 #chado-custom-search-form .form-item .description {
   font-style: italic;
@@ -91,4 +95,24 @@
 }
 #chado-custom-search-form .crossingblock-element select {
   width: 225px;
+}
+
+/*  - Parentage Filter   */
+#chado-custom-search-form .parentage-element .form-item label {
+  display: none;
+}
+#chado-custom-search-form .parentage-element .form-item .description {
+  display: none;
+}
+#chado-custom-search-form .parentage-element .form-item {
+  display: inline-block;
+  margin-bottom: 2px;
+}
+#chado-custom-search-form .parentage-element input {
+  width: 200px;
+}
+#chado-custom-search-form .parentage-element span.divider {
+  font-weight: bolder;
+  font-size: 1.1em;
+  padding: 0px 10px;
 }

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -15,6 +15,10 @@
 #chado-custom-search-form .form-item .description {
   font-style: italic;
 }
+/* - Remove the bottom border of the header */
+#chado-custom-search-form thead tr th {
+  border-bottom: 1px solid #40576e;
+}
 
 /**
  * Genetic Marker Search.

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -8,7 +8,7 @@
 }
 
 /* - Ensure all textfields match the select boxes in length. */
-#chado-custom-search-form .form-item input {
+#chado-custom-search-form .form-item input.form-text {
   width: 440px;
 }
 /* - Make the filter element help italicized. */
@@ -98,17 +98,19 @@
 }
 
 /*  - Parentage Filter   */
-#chado-custom-search-form .parentage-element .form-item label {
+#chado-custom-search-form .parentage-element .form-item.form-type-textfield label {
   display: none;
 }
 #chado-custom-search-form .parentage-element .form-item .description {
   display: none;
 }
 #chado-custom-search-form .parentage-element .form-item {
-  display: inline-block;
   margin-bottom: 2px;
 }
-#chado-custom-search-form .parentage-element input {
+#chado-custom-search-form .parentage-element .form-item.form-type-textfield {
+  display: inline-block;
+}
+#chado-custom-search-form .parentage-element input.form-text {
   width: 200px;
 }
 #chado-custom-search-form .parentage-element span.divider {

--- a/includes/BreedingCrossSearch.inc
+++ b/includes/BreedingCrossSearch.inc
@@ -109,6 +109,14 @@ class BreedingCrossSearch extends GermplasmSearch {
         'title' => 'Species',
         'help' => 'The legume species the germplasm belongs to (e.g. culinaris).',
       ],
+      'crossingblock_year' => [
+        'title' => 'Crossing Block Year',
+        'help' => 'The year of the crossing block you are interested in.',
+      ],
+      'crossingblock_season' => [
+        'title' => 'Crossing Block Season',
+        'help' => 'The season of the crossing block you are interested in.',
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -139,6 +147,46 @@ class BreedingCrossSearch extends GermplasmSearch {
 
     // Add a Scientific name selector.
     $this->addSpeciesFormElement($form, $form_state);
+
+    // Make the crossing block filter more intuitive.
+    $description = 'The block of crosses you are interested in. Specifically, this is the year/season that the seed from the original cross was generated in.';
+    $form['crossingblock'] = array(
+      '#type' => 'markup',
+      '#prefix' => '<div class="crossingblock-element form-item"><label>Crossing Block</label>',
+      '#suffix' => '<div class="description">' . $description . '</div></div>',
+      '#weight' => -7,
+    );
+
+    $q = drupal_get_query_parameters();
+    if (isset($form_state['values'])) {
+      $cbyear_default = $form_state['values']['crossingblock_year'];
+      $cbseason_default = $form_state['values']['crossingblock_season'];
+    }
+    elseif (isset($q['crossingblock_year'])) {
+      $cbyear_default = $q['crossingblock_year'];
+      $cbseason_default = $q['crossingblock_season'];
+    }
+    else {
+      $cbyear_default = date('Y');
+      $cbseason_default = NULL;
+    }
+
+    $seasons_flat = ['Winter', 'Spring', 'Summer', 'Fall'];
+    $seasons = array_combine($seasons_flat, $seasons_flat);
+    $form['crossingblock']['crossingblock_season'] = $form['species'];
+    $form['crossingblock']['crossingblock_season']['#type'] = 'select';
+    $form['crossingblock']['crossingblock_season']['#options'] = $seasons;
+    $form['crossingblock']['crossingblock_season']['#empty_option'] = '- Select Season -';
+    $form['crossingblock']['crossingblock_season']['#default_value'] = $cbseason_default;
+    unset($form['crossingblock_season']);
+    
+    $years = array_combine(range(date("Y"), 1996), range(date("Y"), 1996));
+    $form['crossingblock']['crossingblock_year'] = $form['species'];
+    $form['crossingblock']['crossingblock_year']['#type'] = 'select';
+    $form['crossingblock']['crossingblock_year']['#options'] = $years;
+    $form['crossingblock']['crossingblock_year']['#empty_option'] = '- Select Year -';
+    $form['crossingblock']['crossingblock_year']['#default_value'] = $cbyear_default;
+    unset($form['crossingblock_year']);
 
     return $form;
   }
@@ -210,6 +258,18 @@ class BreedingCrossSearch extends GermplasmSearch {
     if ($filter_results['name'] != '') {
       $where[] = "(s.name ~ :name OR s.uniquename = :name)";
       $args[':name'] = $filter_results['name'];
+    }
+
+    // -- Crossing Block Year.
+    if ($filter_results['crossingblock_year'] != '') {
+      $where[] = "cbyear.value = :cbyear";
+      $args[':cbyear'] = $filter_results['crossingblock_year'];
+    }
+
+    // -- Crossing Block Season.
+    if ($filter_results['crossingblock_season'] != '') {
+      $where[] = "cbseason.value = :cbseason";
+      $args[':cbseason'] = $filter_results['crossingblock_season'];
     }
 
     // Finally, add it to the query.

--- a/includes/BreedingCrossSearch.inc
+++ b/includes/BreedingCrossSearch.inc
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Provides a search specific to breeding crosses.
+ */
+class BreedingCrossSearch extends GermplasmSearch {
+
+  /**
+   * The human readable title of this search. This will be used in listings
+   * and shown on the search page as the title.
+   */
+  public static $title = 'Breeding Cross Search';
+
+  /**
+   * The machine name of the module providing this search.
+   */
+  public static $module = 'kp_searches';
+
+  /**
+   * A description of this search. This is shown at the top of the search page
+   * and used for the menu item.
+   */
+  public static $description = '';
+
+  /**
+   * The machine names of the permissions with access to this search. This is
+   * used to map your search to existing permissions. It must be an array and
+   * is used in hook_menu(). Some examples include 'access content'
+   * and 'administer tripal'.
+   */
+  public static $permissions = ['view bio_data_21'];
+
+  /**
+   * If TRUE, this search will require the submit button to be clicked before
+   * executing the query; whereas, if FALSE it will be executed on the
+   * first page load without parameters.
+   *
+   * NOTE: to control the results without parameters check $this->submitted
+   * in getQuery() and if FALSE return your pre-submit query.
+   */
+  public static $require_submit = TRUE;
+
+  /**
+   * Add a pager to search results
+   * with $num_items_per_page results on a single page.
+   * NOTE: Your query has to handle paging.
+   */
+  public static $pager = TRUE;
+  public static $num_items_per_page = 50;
+
+  /**
+   * This defined the hook_menu definition for this search. At a minimum the
+   * path is required.
+   */
+  public static $menu = [
+    'path' => 'search/germplasm/crosses',
+    // @todo support menu items.
+  ];
+
+  /**
+   * Add CSS/JS to the form/results page.
+   * NOTE: paths supplied should be relative to $module.
+   */
+  public static $attached = [
+    'css' => [
+      'css/all_kp_searches.css',
+    ],
+    'js' => [],
+  ];
+
+  /**
+   * Information regarding the fields and filters for this search.
+   */
+  public static $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'stock_id'
+        ],
+      ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'mom_id'
+        ],
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'dad_id'
+        ],
+      ],
+      'crossingblock' => [
+        'title' => 'Crossing Block',
+      ],
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume genus the germplasm belongs to (e.g. Lens).',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => 'The legume species the germplasm belongs to (e.g. culinaris).',
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Text that should appear on the button at the bottom of the importer
+   * form.
+   */
+  public static $button_text = 'Search';
+
+  /**
+   * Generate the filter form.
+   *
+   * The base class will generate textfields for each filter defined in $info,
+   * set defaults, labels and descriptions, as well as, create the search
+   * button.
+   *
+   * Extend this method to alter the filter form.
+   */
+  public function form($form, $form_state) {
+    $form = ChadoCustomSearch::form($form, $form_state);
+
+    // Add a crop selector.
+    $this->addCropFormElement($form, $form_state);
+
+    // Add a Scientific name selector.
+    $this->addSpeciesFormElement($form, $form_state);
+
+    return $form;
+  }
+  /**
+   * Allows custom searches to validate the form results.
+   * Use form_set_error() to signal invalid values.
+   */
+  public function validateForm($form, $form_state) { }
+
+  /**
+   * Determine the query for the genetic marker search.
+   *
+   * @param string $query
+   *   The full SQL query to execute. This will be executed using chado_query()
+   *   so use curly brackets appropriately. Use :placeholders for any values.
+   * @param array $args
+   *   An array of arguments to pass to chado_query(). Keys must be the
+   *   placeholders in the query and values should be what you want them set to.
+   */
+  public function getQuery(&$query, &$args, $offset) {
+    global $user;
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+    // @debug dpm($filter_results, '$filter_results');
+
+    $query = "SELECT
+        s.name,
+        s.uniquename,
+        s.stock_id,
+        cbseason.value||' '||cbyear.value as crossingblock,
+        mom.name as mom,
+        mom.stock_id as mom_id,
+        dad.name as dad,
+        dad.stock_id as dad_id
+      FROM {stock} s
+      LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+      LEFT JOIN {stockprop} cbyear ON cbyear.stock_id=s.stock_id
+        AND cbyear.type_id = 3978
+      LEFT JOIN {stockprop} cbseason ON cbseason.stock_id=s.stock_id
+        AND cbseason.type_id = 3977
+      LEFT JOIN {stock_relationship} momr ON momr.object_id=s.stock_id
+        AND momr.type_id=3632
+      LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
+      LEFT JOIN {stock_relationship} dadr ON dadr.object_id=s.stock_id
+        AND dadr.type_id=3633
+      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
+
+    $where = [];
+    $joins = [];
+
+    // -- Restrict to Breeding Crosses.
+    $where[] = 's.type_id=:type_id';
+    $args[':type_id'] = 4335;
+
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "o.genus ~ :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "o.species ~ :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "(s.name ~ :name OR s.uniquename = :name)";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n",$joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ',$where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY s.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+}

--- a/includes/BreedingCrossSearch.inc
+++ b/includes/BreedingCrossSearch.inc
@@ -117,6 +117,14 @@ class BreedingCrossSearch extends GermplasmSearch {
         'title' => 'Crossing Block Season',
         'help' => 'The season of the crossing block you are interested in.',
       ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'help' => 'The maternal parent of the germplasm you are interested in.'
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'help' => 'The paternal parent of the germplasm you are interested in.'
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -147,6 +155,9 @@ class BreedingCrossSearch extends GermplasmSearch {
 
     // Add a Scientific name selector.
     $this->addSpeciesFormElement($form, $form_state);
+
+    // Add a Maternal/paternal name selector.
+    $this->addparentageFormElement($form, $form_state);
 
     // Make the crossing block filter more intuitive.
     $description = 'The block of crosses you are interested in. Specifically, this is the year/season that the seed from the original cross was generated in.';
@@ -179,7 +190,7 @@ class BreedingCrossSearch extends GermplasmSearch {
     $form['crossingblock']['crossingblock_season']['#empty_option'] = '- Select Season -';
     $form['crossingblock']['crossingblock_season']['#default_value'] = $cbseason_default;
     unset($form['crossingblock_season']);
-    
+
     $years = array_combine(range(date("Y"), 1996), range(date("Y"), 1996));
     $form['crossingblock']['crossingblock_year'] = $form['species'];
     $form['crossingblock']['crossingblock_year']['#type'] = 'select';
@@ -187,6 +198,9 @@ class BreedingCrossSearch extends GermplasmSearch {
     $form['crossingblock']['crossingblock_year']['#empty_option'] = '- Select Year -';
     $form['crossingblock']['crossingblock_year']['#default_value'] = $cbyear_default;
     unset($form['crossingblock_year']);
+
+    // Move name to the bottom.
+    $form['name']['#weight'] = 10;
 
     return $form;
   }
@@ -270,6 +284,18 @@ class BreedingCrossSearch extends GermplasmSearch {
     if ($filter_results['crossingblock_season'] != '') {
       $where[] = "cbseason.value = :cbseason";
       $args[':cbseason'] = $filter_results['crossingblock_season'];
+    }
+
+    // -- Maternal Parent.
+    if ($filter_results['mom'] != '') {
+      $where[] = "(mom.name ~ :mom OR mom.uniquename = :mom)";
+      $args[':mom'] = $filter_results['mom'];
+    }
+
+    // -- Paternal Parent.
+    if ($filter_results['dad'] != '') {
+      $where[] = "(dad.name ~ :dad OR dad.uniquename = :dad)";
+      $args[':dad'] = $filter_results['dad'];
     }
 
     // Finally, add it to the query.

--- a/includes/BreedingCrossSearch.inc
+++ b/includes/BreedingCrossSearch.inc
@@ -125,6 +125,10 @@ class BreedingCrossSearch extends GermplasmSearch {
         'title' => 'Paternal Parent',
         'help' => 'The paternal parent of the germplasm you are interested in.'
       ],
+      'reciprocal_crosses' => [
+        'title' => 'Include reciprocal crosses',
+        'help' => 'Includes both A x B and B x A crosses when using the parentage filter.',
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -258,19 +262,19 @@ class BreedingCrossSearch extends GermplasmSearch {
 
     // -- Genus.
     if ($filter_results['genus'] != '') {
-      $where[] = "o.genus ~ :genus";
+      $where[] = "o.genus ~* :genus";
       $args[':genus'] = $filter_results['genus'];
     }
 
     // -- Species.
     if ($filter_results['species'] != '') {
-      $where[] = "o.species ~ :species";
+      $where[] = "o.species ~* :species";
       $args[':species'] = $filter_results['species'];
     }
 
     // -- Name.
     if ($filter_results['name'] != '') {
-      $where[] = "(s.name ~ :name OR s.uniquename = :name)";
+      $where[] = "(s.name ~* :name OR s.uniquename = :name)";
       $args[':name'] = $filter_results['name'];
     }
 
@@ -286,17 +290,8 @@ class BreedingCrossSearch extends GermplasmSearch {
       $args[':cbseason'] = $filter_results['crossingblock_season'];
     }
 
-    // -- Maternal Parent.
-    if ($filter_results['mom'] != '') {
-      $where[] = "(mom.name ~ :mom OR mom.uniquename = :mom)";
-      $args[':mom'] = $filter_results['mom'];
-    }
-
-    // -- Paternal Parent.
-    if ($filter_results['dad'] != '') {
-      $where[] = "(dad.name ~ :dad OR dad.uniquename = :dad)";
-      $args[':dad'] = $filter_results['dad'];
-    }
+    // -- Parents.
+    $this->addParentageQuery($filter_results, $where, $args);
 
     // Finally, add it to the query.
     if (!empty($joins)) {

--- a/includes/CultivarSearch.inc
+++ b/includes/CultivarSearch.inc
@@ -97,6 +97,12 @@ class CultivarSearch extends GermplasmSearch {
       'source_institute' => [
         'title' => 'Source Institute',
       ],
+      'market_class' => [
+        'title' => 'Market Class',
+      ],
+      'yr_released' => [
+        'title' => 'Year Released',
+      ],
     ],
     // The filter criteria available to the user.
     // This is used to generate a search form which can be altered.
@@ -112,6 +118,10 @@ class CultivarSearch extends GermplasmSearch {
       'source_institute' => [
         'title' => 'Source Institute',
         'help' => 'The institute the germplasm was developed or collected by.'
+      ],
+      'market_class' => [
+        'title' => 'Market Class',
+        'help' => 'Groupings from each crop based on phenotypic traits desirable by economic groups (e.g. Large Red).'
       ],
       'mom' => [
         'title' => 'Maternal Parent',
@@ -197,6 +207,8 @@ class CultivarSearch extends GermplasmSearch {
         s.uniquename,
         s.stock_id,
         source.value as source_institute,
+        released.value as yr_released,
+        market.value as market_class,
         mom.name as mom,
         mom.stock_id as mom_id,
         dad.name as dad,
@@ -204,6 +216,9 @@ class CultivarSearch extends GermplasmSearch {
       FROM {stock} s
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
       LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
+      LEFT JOIN {stockprop} market ON market.stock_id=s.stock_id
+        AND (market.type_id=4086 OR market.type_id=3682)
+      LEFT JOIN {stockprop} released ON released.stock_id=s.stock_id AND released.type_id=3688
       LEFT JOIN {stock_relationship} regcultivar ON regcultivar.subject_id=s.stock_id
         AND regcultivar.type_id = 3679
       LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=regcultivar.object_id
@@ -240,6 +255,12 @@ class CultivarSearch extends GermplasmSearch {
     if ($filter_results['source_institute'] != '') {
       $where[] = "source.value ~* :source_institute";
       $args[':source_institute'] = $filter_results['source_institute'];
+    }
+
+    // -- Market Class
+    if ($filter_results['market_class'] != '') {
+      $where[] = "market.value ~* :market_class";
+      $args[':market_class'] = $filter_results['market_class'];
     }
 
     // -- Parents.

--- a/includes/CultivarSearch.inc
+++ b/includes/CultivarSearch.inc
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Provides a search specific to breeding crosses.
+ */
+class CultivarSearch extends GermplasmSearch {
+
+  /**
+   * The human readable title of this search. This will be used in listings
+   * and shown on the search page as the title.
+   */
+  public static $title = 'Registered Variety Search';
+
+  /**
+   * The machine name of the module providing this search.
+   */
+  public static $module = 'kp_searches';
+
+  /**
+   * A description of this search. This is shown at the top of the search page
+   * and used for the menu item.
+   */
+  public static $description = '';
+
+  /**
+   * The machine names of the permissions with access to this search. This is
+   * used to map your search to existing permissions. It must be an array and
+   * is used in hook_menu(). Some examples include 'access content'
+   * and 'administer tripal'.
+   */
+  public static $permissions = ['view bio_data_22'];
+
+  /**
+   * If TRUE, this search will require the submit button to be clicked before
+   * executing the query; whereas, if FALSE it will be executed on the
+   * first page load without parameters.
+   *
+   * NOTE: to control the results without parameters check $this->submitted
+   * in getQuery() and if FALSE return your pre-submit query.
+   */
+  public static $require_submit = TRUE;
+
+  /**
+   * Add a pager to search results
+   * with $num_items_per_page results on a single page.
+   * NOTE: Your query has to handle paging.
+   */
+  public static $pager = TRUE;
+  public static $num_items_per_page = 50;
+
+  /**
+   * This defined the hook_menu definition for this search. At a minimum the
+   * path is required.
+   */
+  public static $menu = [
+    'path' => 'search/germplasm/varieties',
+    // @todo support menu items.
+  ];
+
+  /**
+   * Add CSS/JS to the form/results page.
+   * NOTE: paths supplied should be relative to $module.
+   */
+  public static $attached = [
+    'css' => [
+      'css/all_kp_searches.css',
+    ],
+    'js' => [],
+  ];
+
+  /**
+   * Information regarding the fields and filters for this search.
+   */
+  public static $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'stock_id'
+        ],
+      ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'mom_id'
+        ],
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'dad_id'
+        ],
+      ],
+      'source_institute' => [
+        'title' => 'Source Institute',
+      ],
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume genus the germplasm belongs to (e.g. Lens).',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => 'The legume species the germplasm belongs to (e.g. culinaris).',
+      ],
+      'source_institute' => [
+        'title' => 'Source Institute',
+        'help' => 'The institute the germplasm was developed or collected by.'
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Text that should appear on the button at the bottom of the importer
+   * form.
+   */
+  public static $button_text = 'Search';
+
+  /**
+   * Generate the filter form.
+   *
+   * The base class will generate textfields for each filter defined in $info,
+   * set defaults, labels and descriptions, as well as, create the search
+   * button.
+   *
+   * Extend this method to alter the filter form.
+   */
+  public function form($form, $form_state) {
+    $form = ChadoCustomSearch::form($form, $form_state);
+
+    // Add a crop selector.
+    $this->addCropFormElement($form, $form_state);
+
+    // Add a Scientific name selector.
+    $this->addSpeciesFormElement($form, $form_state);
+
+    return $form;
+  }
+  /**
+   * Allows custom searches to validate the form results.
+   * Use form_set_error() to signal invalid values.
+   */
+  public function validateForm($form, $form_state) { }
+
+  /**
+   * Determine the query for the genetic marker search.
+   *
+   * @param string $query
+   *   The full SQL query to execute. This will be executed using chado_query()
+   *   so use curly brackets appropriately. Use :placeholders for any values.
+   * @param array $args
+   *   An array of arguments to pass to chado_query(). Keys must be the
+   *   placeholders in the query and values should be what you want them set to.
+   */
+  public function getQuery(&$query, &$args, $offset) {
+    global $user;
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+    // @debug dpm($filter_results, '$filter_results');
+
+    // To get the parents...
+    // 1) Cultivar -is_registered_cultivar_of-> individual -is_selection_of-> cross
+    // 2) Cultivar -is_registered_cultivar_of-> cross
+    // type_id: is_registered_cultivar_of = 3679; is_selection_of = 3684;
+    //    source_institute = 3711
+    $query = "SELECT
+        s.name,
+        s.uniquename,
+        s.stock_id,
+        source.value as source_institute,
+        mom.name as mom,
+        mom.stock_id as mom_id,
+        dad.name as dad,
+        dad.stock_id as dad_id
+      FROM {stock} s
+      LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+      LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
+      LEFT JOIN {stock_relationship} regcultivar ON regcultivar.subject_id=s.stock_id
+        AND regcultivar.type_id = 3679
+      LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=regcultivar.object_id
+        AND origcross.type_id = 3684
+      LEFT JOIN {stock_relationship} momr
+        ON (momr.object_id=origcross.object_id OR momr.object_id=regcultivar.object_id)
+        AND momr.type_id=3632
+      LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
+      LEFT JOIN {stock_relationship} dadr
+        ON (dadr.object_id=origcross.object_id OR dadr.object_id=regcultivar.object_id)
+        AND dadr.type_id=3633
+      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
+
+    $where = [];
+    $joins = [];
+
+    // -- Restrict to Breeding Crosses.
+    $where[] = 's.type_id=:type_id';
+    $args[':type_id'] = 4991;
+
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "o.genus ~ :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "o.species ~ :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Species.
+    if ($filter_results['source_institute'] != '') {
+      $where[] = "source.value ~ :source_institute";
+      $args[':source_institute'] = $filter_results['source_institute'];
+    }
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "(s.name ~ :name OR s.uniquename = :name)";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n",$joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ',$where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY s.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+}

--- a/includes/CultivarSearch.inc
+++ b/includes/CultivarSearch.inc
@@ -121,6 +121,10 @@ class CultivarSearch extends GermplasmSearch {
         'title' => 'Paternal Parent',
         'help' => 'The paternal parent of the germplasm you are interested in.'
       ],
+      'reciprocal_crosses' => [
+        'title' => 'Include reciprocal crosses',
+        'help' => 'Includes both A x B and B x A crosses when using the parentage filter.',
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -222,7 +226,7 @@ class CultivarSearch extends GermplasmSearch {
 
     // -- Genus.
     if ($filter_results['genus'] != '') {
-      $where[] = "o.genus ~ :genus";
+      $where[] = "o.genus ~* :genus";
       $args[':genus'] = $filter_results['genus'];
     }
 
@@ -234,25 +238,16 @@ class CultivarSearch extends GermplasmSearch {
 
     // -- Source Institute.
     if ($filter_results['source_institute'] != '') {
-      $where[] = "source.value ~ :source_institute";
+      $where[] = "source.value ~* :source_institute";
       $args[':source_institute'] = $filter_results['source_institute'];
     }
 
-    // -- Maternal Parent.
-    if ($filter_results['mom'] != '') {
-      $where[] = "(mom.name ~ :mom OR mom.uniquename = :mom)";
-      $args[':mom'] = $filter_results['mom'];
-    }
-
-    // -- Paternal Parent.
-    if ($filter_results['dad'] != '') {
-      $where[] = "(dad.name ~ :dad OR dad.uniquename = :dad)";
-      $args[':dad'] = $filter_results['dad'];
-    }
+    // -- Parents.
+    $this->addParentageQuery($filter_results, $where, $args);
 
     // -- Name.
     if ($filter_results['name'] != '') {
-      $where[] = "(s.name ~ :name OR s.uniquename = :name)";
+      $where[] = "(s.name ~* :name OR s.uniquename = :name)";
       $args[':name'] = $filter_results['name'];
     }
 

--- a/includes/CultivarSearch.inc
+++ b/includes/CultivarSearch.inc
@@ -218,7 +218,7 @@ class CultivarSearch extends GermplasmSearch {
       $args[':species'] = $filter_results['species'];
     }
 
-    // -- Species.
+    // -- Source Institute.
     if ($filter_results['source_institute'] != '') {
       $where[] = "source.value ~ :source_institute";
       $args[':source_institute'] = $filter_results['source_institute'];

--- a/includes/CultivarSearch.inc
+++ b/includes/CultivarSearch.inc
@@ -113,6 +113,14 @@ class CultivarSearch extends GermplasmSearch {
         'title' => 'Source Institute',
         'help' => 'The institute the germplasm was developed or collected by.'
       ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'help' => 'The maternal parent of the germplasm you are interested in.'
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'help' => 'The paternal parent of the germplasm you are interested in.'
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -143,6 +151,12 @@ class CultivarSearch extends GermplasmSearch {
 
     // Add a Scientific name selector.
     $this->addSpeciesFormElement($form, $form_state);
+
+    // Add a Maternal/paternal name selector.
+    $this->addparentageFormElement($form, $form_state);
+
+    // Move name to the bottom.
+    $form['name']['#weight'] = 10;
 
     return $form;
   }
@@ -222,6 +236,18 @@ class CultivarSearch extends GermplasmSearch {
     if ($filter_results['source_institute'] != '') {
       $where[] = "source.value ~ :source_institute";
       $args[':source_institute'] = $filter_results['source_institute'];
+    }
+
+    // -- Maternal Parent.
+    if ($filter_results['mom'] != '') {
+      $where[] = "(mom.name ~ :mom OR mom.uniquename = :mom)";
+      $args[':mom'] = $filter_results['mom'];
+    }
+
+    // -- Paternal Parent.
+    if ($filter_results['dad'] != '') {
+      $where[] = "(dad.name ~ :dad OR dad.uniquename = :dad)";
+      $args[':dad'] = $filter_results['dad'];
     }
 
     // -- Name.

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -129,6 +129,10 @@ class GermplasmSearch extends ChadoCustomSearch {
         'title' => 'Paternal Parent',
         'help' => 'The paternal parent of the germplasm you are interested in.'
       ],
+      'reciprocal_crosses' => [
+        'title' => 'Include reciprocal crosses',
+        'help' => 'Includes both A x B and B x A crosses when using the parentage filter.',
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -321,14 +325,17 @@ class GermplasmSearch extends ChadoCustomSearch {
     if (isset($form_state['values'])) {
       $mom_default = $form_state['values']['mom'];
       $dad_default = $form_state['values']['dad'];
+      $reciprocal = $form_state['values']['reciprocal_crosses'];
     }
     elseif (isset($q['mom'])) {
       $mom_default = $q['mom'];
       $dad_default = $q['dad'];
+      $reciprocal = $q['reciprocal_crosses'];
     }
     else {
       $mom_default = '';
       $dad_default = '';
+      $reciprocal = TRUE;
     }
 
     $form['parentage']['mom'] = $form['mom'];
@@ -349,6 +356,11 @@ class GermplasmSearch extends ChadoCustomSearch {
 
     $form['parentage']['dad']['#default_value'] = $dad_default;
     unset($form['dad']);
+
+    $form['parentage']['reciprocal_crosses'] = $form['reciprocal_crosses'];
+    $form['parentage']['reciprocal_crosses']['#type'] = 'checkbox';
+    $form['parentage']['reciprocal_crosses']['#default_value'] = $reciprocal;
+    unset($form['reciprocal_crosses']);
 
     // Add autocompletes if genus is available.
     if (isset($form['scientific_name']['genus']['#default_value'])
@@ -403,13 +415,13 @@ class GermplasmSearch extends ChadoCustomSearch {
 
     // -- Genus.
     if ($filter_results['genus'] != '') {
-      $where[] = "o.genus ~ :genus";
+      $where[] = "o.genus ~* :genus";
       $args[':genus'] = $filter_results['genus'];
     }
 
     // -- Species.
     if ($filter_results['species'] != '') {
-      $where[] = "o.species ~ :species";
+      $where[] = "o.species ~* :species";
       $args[':species'] = $filter_results['species'];
     }
 
@@ -421,33 +433,27 @@ class GermplasmSearch extends ChadoCustomSearch {
 
     // -- Source Institute.
     if ($filter_results['source_institute'] != '') {
-      $where[] = "source.value ~ :source_institute";
+      $where[] = "source.value ~* :source_institute";
       $args[':source_institute'] = $filter_results['source_institute'];
     }
 
     // -- Name.
     if ($filter_results['name'] != '') {
-      $where[] = "(s.name ~ :name OR s.uniquename = :name)";
+      $where[] = "(s.name ~* :name OR s.uniquename = :name)";
       $args[':name'] = $filter_results['name'];
     }
 
-    // -- Maternal Parent.
-    if ($filter_results['mom'] != '') {
+    // Add Parental Filter to query.
+    if ($filter_results['mom'] != '' OR $filter_results['dad'] != '') {
       $joins[] = "LEFT JOIN {stock_relationship} momr ON momr.object_id=s.stock_id
         AND momr.type_id=3632";
       $joins[] = "LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id";
-      $where[] = "(mom.name ~ :mom OR mom.uniquename = :mom)";
-      $args[':mom'] = $filter_results['mom'];
-    }
-
-    // -- Paternal Parent.
-    if ($filter_results['dad'] != '') {
       $joins[] = "LEFT JOIN {stock_relationship} dadr ON dadr.object_id=s.stock_id
         AND dadr.type_id=3633";
       $joins[] = "LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
-      $where[] = "(dad.name ~ :dad OR dad.uniquename = :dad)";
-      $args[':dad'] = $filter_results['dad'];
     }
+    $this->addParentageQuery($filter_results, $where, $args);
+
 
     // -- ADD IN ACCESS CONTROL!
     // Only use access control for non administrators. This is put in place to
@@ -486,5 +492,50 @@ class GermplasmSearch extends ChadoCustomSearch {
     $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
 
     // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+
+  /**
+   * Adds the necessary components to the query to filter by parent.
+   * REQUIRES: pre-exising JOINS connecting a "mom" and "dad" table alias.
+   */
+  public function addParentageQuery($filter_results, &$where, &$args) {
+
+    if ($filter_results['reciprocal_crosses']) {
+      // -- Maternal & Paternal Parent.
+      if ($filter_results['mom'] != '' AND $filter_results['dad'] != '') {
+        $forward_clause = "(mom.name ~* :mom OR mom.uniquename = :mom) AND (dad.name ~* :dad OR dad.uniquename = :dad)";
+        $reciprocal_clause = "(mom.name ~* :dad OR mom.uniquename = :dad) AND (dad.name ~* :mom OR dad.uniquename = :mom)";
+        $where[] = "(($forward_clause) OR ($reciprocal_clause))";
+        $args[':mom'] = $filter_results['mom'];
+        $args[':dad'] = $filter_results['dad'];
+      }
+      // -- Just Maternal provided.
+      elseif ($filter_results['mom'] != '') {
+        $forward_clause = "mom.name ~* :mom OR mom.uniquename = :mom";
+        $reciprocal_clause = "dad.name ~* :mom OR dad.uniquename = :mom";
+        $where[] = "(($forward_clause) OR ($reciprocal_clause))";
+        $args[':mom'] = $filter_results['mom'];
+      }
+      // -- Just Paternal provided.
+      elseif ($filter_results['dad'] != '') {
+        $forward_clause = "dad.name ~* :dad OR dad.uniquename = :dad";
+        $reciprocal_clause = "mom.name ~* :dad OR mom.uniquename = :dad";
+        $where[] = "(($forward_clause) OR ($reciprocal_clause))";
+        $args[':dad'] = $filter_results['dad'];
+      }
+    }
+    else {
+      // -- Maternal Parent.
+      if ($filter_results['mom'] != '') {
+        $where[] = "(mom.name ~* :mom OR mom.uniquename = :mom)";
+        $args[':mom'] = $filter_results['mom'];
+      }
+
+      // -- Paternal Parent.
+      if ($filter_results['dad'] != '') {
+        $where[] = "(dad.name ~* :dad OR dad.uniquename = :dad)";
+        $args[':dad'] = $filter_results['dad'];
+      }
+    }
   }
 }

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -91,6 +91,9 @@ class GermplasmSearch extends ChadoCustomSearch {
       'type' => [
         'title' => 'Category',
       ],
+      'source_institute' => [
+        'title' => 'Source Institute',
+      ],
       'species' => [
         'title' => 'Source Species',
         'entity_link' => [
@@ -113,6 +116,10 @@ class GermplasmSearch extends ChadoCustomSearch {
       'type' => [
         'title' => 'Category',
         'help' => 'The category this germplasm belongs to (e.g. Breeding Cross).',
+      ],
+      'source_institute' => [
+        'title' => 'Source Institute',
+        'help' => 'The institute the germplasm was developed or collected by.'
       ],
       'name' => [
         'title' => 'Name',
@@ -307,9 +314,16 @@ class GermplasmSearch extends ChadoCustomSearch {
     $filter_results = $this->values;
     // @debug dpm($filter_results, '$filter_results');
 
-    $query = "SELECT o.genus||' '||o.species as species, o.organism_id, s.name, s.uniquename, s.stock_id, tb.label as type
+    $query = "SELECT
+        o.genus||' '||o.species as species,
+        o.organism_id,
+        s.name, s.uniquename,
+        s.stock_id,
+        tb.label as type,
+        source.value as source_institute
       FROM {stock} s
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+      LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
       LEFT JOIN chado_bundle cb ON cb.type_id=s.type_id
       LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id";
 
@@ -332,6 +346,12 @@ class GermplasmSearch extends ChadoCustomSearch {
     if ($filter_results['type'] != '') {
       $where[] = "(s.type_id = :type)";
       $args[':type'] = $filter_results['type'];
+    }
+
+    // -- Source Institute.
+    if ($filter_results['source_institute'] != '') {
+      $where[] = "source.value ~ :source_institute";
+      $args[':source_institute'] = $filter_results['source_institute'];
     }
 
     // -- Name.

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -121,6 +121,14 @@ class GermplasmSearch extends ChadoCustomSearch {
         'title' => 'Source Institute',
         'help' => 'The institute the germplasm was developed or collected by.'
       ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'help' => 'The maternal parent of the germplasm you are interested in.'
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'help' => 'The paternal parent of the germplasm you are interested in.'
+      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
@@ -157,6 +165,13 @@ class GermplasmSearch extends ChadoCustomSearch {
     $form['type']['#type'] = 'select';
     $form['type']['#options'] = $options;
     $form['type']['#empty_option'] = '- Select -';
+    $form['type']['#weight'] = -7;
+
+    // Add a Maternal/paternal name selector.
+    $this->addparentageFormElement($form, $form_state);
+
+    // Move name to the bottom.
+    $form['name']['#weight'] = 10;
 
     return $form;
   }
@@ -290,6 +305,62 @@ class GermplasmSearch extends ChadoCustomSearch {
   }
 
   /**
+   * Adds a Maternal / Paternal Parent filter element.
+   */
+  public function addparentageFormElement(&$form, &$form_state) {
+
+    $description = 'The parents of the germplasm you are interested in (single parents welcomed).';
+    $form['parentage'] = array(
+      '#type' => 'markup',
+      '#prefix' => '<div class="parentage-element form-item"><label>Parentage</label>',
+      '#suffix' => '<div class="description">' . $description . '</div></div>',
+      '#weight' => 9,
+    );
+
+    $q = drupal_get_query_parameters();
+    if (isset($form_state['values'])) {
+      $mom_default = $form_state['values']['mom'];
+      $dad_default = $form_state['values']['dad'];
+    }
+    elseif (isset($q['mom'])) {
+      $mom_default = $q['mom'];
+      $dad_default = $q['dad'];
+    }
+    else {
+      $mom_default = '';
+      $dad_default = '';
+    }
+
+    $form['parentage']['mom'] = $form['mom'];
+    $form['parentage']['mom']['#attributes']['placeholder'] = 'Maternal Parent';
+
+    $form['parentage']['mom']['#default_value'] = $mom_default;
+    unset($form['mom']);
+
+    $form['parentage']['divider'] = [
+      '#type' => 'markup',
+      '#markup' => '/',
+      '#prefix' => '<span class="divider">',
+      '#suffix' => '</span>',
+    ];
+
+    $form['parentage']['dad'] = $form['dad'];
+    $form['parentage']['dad']['#attributes']['placeholder'] = 'Paternal Parent';
+
+    $form['parentage']['dad']['#default_value'] = $dad_default;
+    unset($form['dad']);
+
+    // Add autocompletes if genus is available.
+    if (isset($form['scientific_name']['genus']['#default_value'])
+      AND $form['scientific_name']['genus']['#default_value'] != '') {
+
+      $genus = $form['scientific_name']['genus']['#default_value'];
+      $form['parentage']['mom']['#autocomplete_path'] = 'search/germplasm/autocomplete.json/'.$genus.'/all';
+      $form['parentage']['dad']['#autocomplete_path'] = 'search/germplasm/autocomplete.json/'.$genus.'/all';
+    }
+  }
+
+  /**
    * Allows custom searches to validate the form results.
    * Use form_set_error() to signal invalid values.
    */
@@ -325,7 +396,7 @@ class GermplasmSearch extends ChadoCustomSearch {
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
       LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
       LEFT JOIN chado_bundle cb ON cb.type_id=s.type_id
-      LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id";
+      LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id ";
 
     $where = [];
     $joins = [];
@@ -358,6 +429,24 @@ class GermplasmSearch extends ChadoCustomSearch {
     if ($filter_results['name'] != '') {
       $where[] = "(s.name ~ :name OR s.uniquename = :name)";
       $args[':name'] = $filter_results['name'];
+    }
+
+    // -- Maternal Parent.
+    if ($filter_results['mom'] != '') {
+      $joins[] = "LEFT JOIN {stock_relationship} momr ON momr.object_id=s.stock_id
+        AND momr.type_id=3632";
+      $joins[] = "LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id";
+      $where[] = "(mom.name ~ :mom OR mom.uniquename = :mom)";
+      $args[':mom'] = $filter_results['mom'];
+    }
+
+    // -- Paternal Parent.
+    if ($filter_results['dad'] != '') {
+      $joins[] = "LEFT JOIN {stock_relationship} dadr ON dadr.object_id=s.stock_id
+        AND dadr.type_id=3633";
+      $joins[] = "LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
+      $where[] = "(dad.name ~ :dad OR dad.uniquename = :dad)";
+      $args[':dad'] = $filter_results['dad'];
     }
 
     // -- ADD IN ACCESS CONTROL!

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -88,6 +88,9 @@ class GermplasmSearch extends ChadoCustomSearch {
           'id_column' => 'stock_id'
         ],
       ],
+      'type' => [
+        'title' => 'Category',
+      ],
       'species' => [
         'title' => 'Source Species',
         'entity_link' => [
@@ -95,10 +98,6 @@ class GermplasmSearch extends ChadoCustomSearch {
           'id_column' => 'organism_id'
         ],
       ],
-      'type' => [
-        'title' => 'Category',
-      ],
-
     ],
     // The filter criteria available to the user.
     // This is used to generate a search form which can be altered.
@@ -266,6 +265,7 @@ class GermplasmSearch extends ChadoCustomSearch {
     }
 
     $form['scientific_name']['genus'] = $form['genus'];
+    $form['scientific_name']['genus']['#required'] = TRUE;
     $form['scientific_name']['genus']['#type'] = 'select';
     $form['scientific_name']['genus']['#options'] = $genus_options;
     $form['scientific_name']['genus']['#empty_option'] = '- Select Genus -';

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -301,6 +301,7 @@ class GermplasmSearch extends ChadoCustomSearch {
    *   placeholders in the query and values should be what you want them set to.
    */
   public function getQuery(&$query, &$args, $offset) {
+    global $user;
 
     // Retrieve the filter results already set.
     $filter_results = $this->values;
@@ -337,6 +338,27 @@ class GermplasmSearch extends ChadoCustomSearch {
     if ($filter_results['name'] != '') {
       $where[] = "(s.name ~ :name OR s.uniquename = :name)";
       $args[':name'] = $filter_results['name'];
+    }
+
+    // -- ADD IN ACCESS CONTROL!
+    // Only use access control for non administrators. This is put in place to
+    // allow administrators to see content "on the cutting room floor"
+    // (i.e. not of any given type).
+    $administrator = array_search('administrator', $user->roles);
+    if (!$administrator) {
+      // See https://github.com/tripal/tripal/blob/7.x-3.x/tripal/includes/tripal.entity.inc#L495
+      $entity_types = db_query("SELECT cb.bundle_id FROM chado_bundle cb
+        WHERE cb.data_table = 'stock'")->fetchCol();
+      // Only includes bundles the current user has access to.
+      $available_bundles = [];
+      foreach($entity_types as $bundle_id) {
+        $bundle_name = 'bio_data_' . $bundle_id;
+        if (user_access('view ' . $bundle_name)) {
+          $available_bundles[] = $bundle_id;
+        }
+      }
+      $where[] = 'cb.bundle_id IN (:bundle_ids)';
+      $args[':bundle_ids'] = $available_bundles;
     }
 
     // Finally, add it to the query.

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -1,0 +1,359 @@
+<?php
+/**
+ * Provides a search for all chado stock-based Tripal Content regardless of type.
+ *
+ */
+class GermplasmSearch extends ChadoCustomSearch {
+
+  /**
+   * The human readable title of this search. This will be used in listings
+   * and shown on the search page as the title.
+   */
+  public static $title = 'Germplasm Search';
+
+  /**
+   * The machine name of the module providing this search.
+   */
+  public static $module = 'kp_searches';
+
+  /**
+   * A description of this search. This is shown at the top of the search page
+   * and used for the menu item.
+   */
+  public static $description = '';
+
+  /**
+   * The machine names of the permissions with access to this search. This is
+   * used to map your search to existing permissions. It must be an array and
+   * is used in hook_menu(). Some examples include 'access content'
+   * and 'administer tripal'.
+   */
+  public static $permissions = ['access content'];
+
+  /**
+   * If TRUE, this search will require the submit button to be clicked before
+   * executing the query; whereas, if FALSE it will be executed on the
+   * first page load without parameters.
+   *
+   * NOTE: to control the results without parameters check $this->submitted
+   * in getQuery() and if FALSE return your pre-submit query.
+   */
+  public static $require_submit = TRUE;
+
+  /**
+   * Add a pager to search results
+   * with $num_items_per_page results on a single page.
+   * NOTE: Your query has to handle paging.
+   */
+  public static $pager = TRUE;
+  public static $num_items_per_page = 50;
+
+  /**
+   * This defined the hook_menu definition for this search. At a minimum the
+   * path is required.
+   */
+  public static $menu = [
+    'path' => 'search/germplasm/all',
+    // @todo support menu items.
+  ];
+
+  /**
+   * Add CSS/JS to the form/results page.
+   * NOTE: paths supplied should be relative to $module.
+   */
+  public static $attached = [
+    'css' => [
+      'css/all_kp_searches.css',
+    ],
+    'js' => [],
+  ];
+
+  /**
+   * Information regarding the fields and filters for this search.
+   */
+  public static $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'stock_id'
+        ],
+      ],
+      'uniquename' => [
+        'title' => 'Accession',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'stock_id'
+        ],
+      ],
+      'species' => [
+        'title' => 'Source Species',
+        'entity_link' => [
+          'chado_table' => 'organism',
+          'id_column' => 'organism_id'
+        ],
+      ],
+      'type' => [
+        'title' => 'Category',
+      ],
+
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume genus the germplasm belongs to (e.g. Lens).',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => 'The legume species the germplasm belongs to (e.g. culinaris).',
+      ],
+      'type' => [
+        'title' => 'Category',
+        'help' => 'The category this germplasm belongs to (e.g. Breeding Cross).',
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Text that should appear on the button at the bottom of the importer
+   * form.
+   */
+  public static $button_text = 'Search';
+
+  /**
+   * Generate the filter form.
+   *
+   * The base class will generate textfields for each filter defined in $info,
+   * set defaults, labels and descriptions, as well as, create the search
+   * button.
+   *
+   * Extend this method to alter the filter form.
+   */
+  public function form($form, $form_state) {
+    $form = parent::form($form, $form_state);
+
+    // Add a crop selector.
+    $this->addCropFormElement($form, $form_state);
+
+    // Add a Scientific name selector.
+    $this->addSpeciesFormElement($form, $form_state);
+
+    // Change category to a drop-down.
+    $options = unserialize(variable_get('kp_searches_germplasm_type_options', 'a:0:{}'));
+    $form['type']['#type'] = 'select';
+    $form['type']['#options'] = $options;
+    $form['type']['#empty_option'] = '- Select -';
+
+    return $form;
+  }
+
+  /**
+   * Adds a KnowPulse-specific crop selector to the form.
+   */
+  public function addCropFormElement(&$form, &$form_state) {
+
+    // Container.
+    $form['crops'] = array(
+      '#type' => 'markup',
+      '#prefix' => '<div class="crop-element form-item"><label>Crop</label>',
+      '#suffix' => '</div>',
+      '#weight' => -9,
+    );
+
+    // Crop options.
+    $options = unserialize(variable_get('kp_searches_crop_options', 'a:0:{}'));
+
+    // Determine the current crop, if one is selected.
+    $q = drupal_get_query_parameters();
+    if (isset($form_state['values'])) {
+      $genus_default = $form_state['values']['genus'];
+    }
+    elseif (is_array($q) AND isset($q['genus'])) {
+      $genus_default = $q['genus'];
+    }
+    else {
+      $genus_default = NULL;
+    }
+
+    // Now add the form elements for each crop.
+    foreach ($options as $crop_key => $crop) {
+
+      // Determine whether this is the active genus or not.
+      $class = 'active';
+      if ($genus_default !== NULL AND $genus_default != $crop_key) {
+        $class = 'inactive';
+      }
+
+      // Format the title as a link to the search.
+      $search_url = $this::$menu['path'];
+      $search_q = $q;
+      $search_q['genus'] = $crop['genus'];
+      $search_q['species'] = $crop['crop-species'];
+      $crop_link = l($crop['title'], $search_url, [
+        'query' => $search_q,
+        'attributes' => ['class' => [$class]]
+      ]);
+
+      // Format the image as a link to the search.
+      $image = theme('image', [
+        'path' => url($crop['image']),
+        'width' => 75,
+        'height' => 75,
+        'alt' => $crop['title'],
+      ]);
+      $crop_img_link = l($image, $search_url, [
+        'html' => TRUE,
+        'query' => $search_q,
+        'attributes' => ['class' => [$class]]
+      ]);
+
+      // Contain both the image and title links in a container
+      // and add to the form.
+      $form['crops'][$crop_key] = [
+        '#type' => 'markup',
+        '#markup' => '<span class="crop">'
+           . '<div class="crop-img">' . $crop_img_link . '</div>'
+           . '<div class="crop-title">' . $crop_link . '</div>'
+           . '</span>',
+      ];
+    }
+  }
+
+  /**
+   * Adds a Scientific name field with the genus set based on crop.
+   * @todo make this AJAX-driven.
+   */
+  public function addSpeciesFormElement(&$form, &$form_state) {
+
+    $description = 'The scientific name (genus, species) for the germplasm you are interested in.';
+    $form['scientific_name'] = array(
+      '#type' => 'markup',
+      '#prefix' => '<div id="scientific-nameform-item" class="scientific-name-element form-item"><label>Scientific Name</label>',
+      '#suffix' => '<div class="description">' . $description . '</div></div>',
+      '#weight' => -8,
+    );
+
+    $options = unserialize(variable_get('kp_searches_crop_options', 'a:0:{}'));
+    $genus_options = [];
+    foreach ($options as $genus => $crop_details) {
+      $genus_options[ $genus ] = $genus;
+    }
+
+    $q = drupal_get_query_parameters();
+    if (isset($form_state['values'])
+      AND isset($options[ $form_state['values']['genus'] ])) {
+      $species = $options[ $form_state['values']['genus'] ]['species'];
+      $genus_default = $form_state['values']['genus'];
+      $species_default = $form_state['values']['species'];
+    }
+    elseif (isset($q['genus']) AND isset($options[ $q['genus'] ])) {
+      $species = $options[ $q['genus'] ]['species'];
+      $genus_default = $q['genus'];
+      $species_default = $q['species'];
+    }
+    else {
+      $genus_default = NULL;
+      $species = [];
+      $species_default = NULL;
+    }
+
+    $form['scientific_name']['genus'] = $form['genus'];
+    $form['scientific_name']['genus']['#type'] = 'select';
+    $form['scientific_name']['genus']['#options'] = $genus_options;
+    $form['scientific_name']['genus']['#empty_option'] = '- Select Genus -';
+    $form['scientific_name']['genus']['#default_value'] = $genus_default;
+    $form['scientific_name']['genus']['#attributes'] = ['onchange' => 'this.form.submit();'];
+    unset($form['genus']);
+
+
+    $form['scientific_name']['species'] = $form['species'];
+    $form['scientific_name']['species']['#type'] = 'select';
+    $form['scientific_name']['species']['#options'] = $species;
+    $form['scientific_name']['species']['#empty_option'] = '- Select Species -';
+    $form['scientific_name']['species']['#default_value'] = $species_default;
+    unset($form['species']);
+  }
+
+  /**
+   * Allows custom searches to validate the form results.
+   * Use form_set_error() to signal invalid values.
+   */
+  public function validateForm($form, $form_state) {
+
+  }
+
+  /**
+   * Determine the query for the genetic marker search.
+   *
+   * @param string $query
+   *   The full SQL query to execute. This will be executed using chado_query()
+   *   so use curly brackets appropriately. Use :placeholders for any values.
+   * @param array $args
+   *   An array of arguments to pass to chado_query(). Keys must be the
+   *   placeholders in the query and values should be what you want them set to.
+   */
+  public function getQuery(&$query, &$args, $offset) {
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+    // @debug dpm($filter_results, '$filter_results');
+
+    $query = "SELECT o.genus||' '||o.species as species, o.organism_id, s.name, s.uniquename, s.stock_id, tb.label as type
+      FROM {stock} s
+      LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+      LEFT JOIN chado_bundle cb ON cb.type_id=s.type_id
+      LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id";
+
+    $where = [];
+    $joins = [];
+
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "o.genus ~ :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "o.species ~ :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Type.
+    if ($filter_results['type'] != '') {
+      $where[] = "(s.type_id = :type)";
+      $args[':type'] = $filter_results['type'];
+    }
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "(s.name ~ :name OR s.uniquename = :name)";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n",$joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ',$where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY s.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+}

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -91,6 +91,9 @@ class GermplasmSearch extends ChadoCustomSearch {
       'type' => [
         'title' => 'Category',
       ],
+      'origin' => [
+        'title' => 'Origin',
+      ],
       'source_institute' => [
         'title' => 'Source Institute',
       ],
@@ -116,6 +119,10 @@ class GermplasmSearch extends ChadoCustomSearch {
       'type' => [
         'title' => 'Category',
         'help' => 'The category this germplasm belongs to (e.g. Breeding Cross).',
+      ],
+      'origin' => [
+        'title' => 'Germplasm Origin',
+        'help' => 'The country the seed originated from.'
       ],
       'source_institute' => [
         'title' => 'Source Institute',
@@ -403,10 +410,12 @@ class GermplasmSearch extends ChadoCustomSearch {
         s.name, s.uniquename,
         s.stock_id,
         tb.label as type,
+        origin.value as origin,
         source.value as source_institute
       FROM {stock} s
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
       LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
+      LEFT JOIN {stockprop} origin ON origin.stock_id=s.stock_id AND origin.type_id=3976
       LEFT JOIN chado_bundle cb ON cb.type_id=s.type_id
       LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id ";
 
@@ -435,6 +444,12 @@ class GermplasmSearch extends ChadoCustomSearch {
     if ($filter_results['source_institute'] != '') {
       $where[] = "source.value ~* :source_institute";
       $args[':source_institute'] = $filter_results['source_institute'];
+    }
+
+    // -- Origin.
+    if ($filter_results['origin'] != '') {
+      $where[] = "origin.value ~* :origin";
+      $args[':origin'] = $filter_results['origin'];
     }
 
     // -- Name.

--- a/includes/RILSearch.inc
+++ b/includes/RILSearch.inc
@@ -87,12 +87,18 @@ class RILSearch extends GermplasmSearch {
           'id_column' => 'mom_id'
         ],
       ],
+      'mom_species' => [
+        'title' => 'Species',
+      ],
       'dad' => [
         'title' => 'Paternal Parent',
         'entity_link' => [
           'chado_table' => 'stock',
           'id_column' => 'dad_id'
         ],
+      ],
+      'dad_species' => [
+        'title' => 'Species',
       ],
     ],
     // The filter criteria available to the user.
@@ -199,8 +205,10 @@ class RILSearch extends GermplasmSearch {
         s.stock_id,
         mom.name as mom,
         mom.stock_id as mom_id,
+        momo.species as mom_species,
         dad.name as dad,
-        dad.stock_id as dad_id
+        dad.stock_id as dad_id,
+        dado.species as dad_species
       FROM {stock} s
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
       LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=s.stock_id
@@ -210,7 +218,9 @@ class RILSearch extends GermplasmSearch {
       LEFT JOIN {stock_relationship} dadr ON dadr.object_id=origcross.object_id
         AND dadr.type_id=3633
       LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
-      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
+      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id
+      LEFT JOIN {organism} momo ON momo.organism_id=mom.organism_id
+      LEFT JOIN {organism} dado ON dado.organism_id=dad.organism_id";
 
     $where = [];
     $joins = [];
@@ -261,5 +271,46 @@ class RILSearch extends GermplasmSearch {
     $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
 
     // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+
+  /**
+   * Format the results within the $form array.
+   *
+   * The base class will format the results as a table.
+   *
+   * @param array $form
+   *   The current form array.
+   * @param array $results
+   *   The results to format. This will be an array of standard objects where
+   *   the keys map to the keys in $info['fields'].
+   */
+  public function formatResults(&$form, $results) {
+    parent::formatResults($form, $results);
+
+    if (isset($form['results'])) {
+      $header1 = [
+        'name' => '',
+        'mom' => [
+          'data' => 'Maternal',
+          'colspan' => 2,
+          'style' => 'text-align: center',
+        ],
+        'dad' => [
+          'data' => 'Paternal',
+          'colspan' => 2,
+          'style' => 'text-align: center',
+        ],
+      ];
+      $header2 = $form['results']['#header'];
+      foreach ($header2 as $key => $label) {
+        $header2[$key] = [
+          'data' => $label,
+          'header' => TRUE,
+        ];
+      }
+
+      $form['results']['#header'] = $header1;
+      array_unshift($form['results']['#rows'], $header2);
+    }
   }
 }

--- a/includes/RILSearch.inc
+++ b/includes/RILSearch.inc
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Provides a search specific to breeding crosses.
+ */
+class RILSearch extends GermplasmSearch {
+
+  /**
+   * The human readable title of this search. This will be used in listings
+   * and shown on the search page as the title.
+   */
+  public static $title = 'Recombinant Inbred Line (RIL) Search';
+
+  /**
+   * The machine name of the module providing this search.
+   */
+  public static $module = 'kp_searches';
+
+  /**
+   * A description of this search. This is shown at the top of the search page
+   * and used for the menu item.
+   */
+  public static $description = '';
+
+  /**
+   * The machine names of the permissions with access to this search. This is
+   * used to map your search to existing permissions. It must be an array and
+   * is used in hook_menu(). Some examples include 'access content'
+   * and 'administer tripal'.
+   */
+  public static $permissions = ['view bio_data_29'];
+
+  /**
+   * If TRUE, this search will require the submit button to be clicked before
+   * executing the query; whereas, if FALSE it will be executed on the
+   * first page load without parameters.
+   *
+   * NOTE: to control the results without parameters check $this->submitted
+   * in getQuery() and if FALSE return your pre-submit query.
+   */
+  public static $require_submit = TRUE;
+
+  /**
+   * Add a pager to search results
+   * with $num_items_per_page results on a single page.
+   * NOTE: Your query has to handle paging.
+   */
+  public static $pager = TRUE;
+  public static $num_items_per_page = 50;
+
+  /**
+   * This defined the hook_menu definition for this search. At a minimum the
+   * path is required.
+   */
+  public static $menu = [
+    'path' => 'search/germplasm/RILs',
+    // @todo support menu items.
+  ];
+
+  /**
+   * Add CSS/JS to the form/results page.
+   * NOTE: paths supplied should be relative to $module.
+   */
+  public static $attached = [
+    'css' => [
+      'css/all_kp_searches.css',
+    ],
+    'js' => [],
+  ];
+
+  /**
+   * Information regarding the fields and filters for this search.
+   */
+  public static $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'stock_id'
+        ],
+      ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'mom_id'
+        ],
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'entity_link' => [
+          'chado_table' => 'stock',
+          'id_column' => 'dad_id'
+        ],
+      ],
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume genus the germplasm belongs to (e.g. Lens).',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => 'The legume species the germplasm belongs to (e.g. culinaris).',
+      ],
+      'mom' => [
+        'title' => 'Maternal Parent',
+        'help' => 'The maternal parent of the germplasm you are interested in.'
+      ],
+      'dad' => [
+        'title' => 'Paternal Parent',
+        'help' => 'The paternal parent of the germplasm you are interested in.'
+      ],
+      'reciprocal_crosses' => [
+        'title' => 'Include reciprocal crosses',
+        'help' => 'Includes both A x B and B x A crosses when using the parentage filter.',
+      ],
+      'show_individiuals' => [
+        'title' => 'Show RIL Individuals',
+        'help' => 'When selected, search results will include RIL individuals (e.g. LR-18-25).'
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name or accession of the germplasm (e.g. CDC Redberry; partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Text that should appear on the button at the bottom of the importer
+   * form.
+   */
+  public static $button_text = 'Search';
+
+  /**
+   * Generate the filter form.
+   *
+   * The base class will generate textfields for each filter defined in $info,
+   * set defaults, labels and descriptions, as well as, create the search
+   * button.
+   *
+   * Extend this method to alter the filter form.
+   */
+  public function form($form, $form_state) {
+    $form = ChadoCustomSearch::form($form, $form_state);
+
+    // Add a crop selector.
+    $this->addCropFormElement($form, $form_state);
+
+    // Add a Scientific name selector.
+    $this->addSpeciesFormElement($form, $form_state);
+
+    // Add a Maternal/paternal name selector.
+    $this->addparentageFormElement($form, $form_state);
+
+    // Change show individuals to a checkbox.
+    $form['show_individiuals']['#type'] = 'checkbox';
+    $form['show_individiuals']['#weight'] = 11;
+
+    // Move name to the bottom.
+    $form['name']['#weight'] = 10;
+
+    return $form;
+  }
+  /**
+   * Allows custom searches to validate the form results.
+   * Use form_set_error() to signal invalid values.
+   */
+  public function validateForm($form, $form_state) { }
+
+  /**
+   * Determine the query for the genetic marker search.
+   *
+   * @param string $query
+   *   The full SQL query to execute. This will be executed using chado_query()
+   *   so use curly brackets appropriately. Use :placeholders for any values.
+   * @param array $args
+   *   An array of arguments to pass to chado_query(). Keys must be the
+   *   placeholders in the query and values should be what you want them set to.
+   */
+  public function getQuery(&$query, &$args, $offset) {
+    global $user;
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+    // @debug dpm($filter_results, '$filter_results');
+
+    // To get the parents...
+    // 1) Cultivar -is_registered_cultivar_of-> individual -is_selection_of-> cross
+    // 2) Cultivar -is_registered_cultivar_of-> cross
+    // type_id: is_registered_cultivar_of = 3679; is_selection_of = 3684;
+    //    source_institute = 3711
+    $query = "SELECT
+        s.name,
+        s.uniquename,
+        s.stock_id,
+        mom.name as mom,
+        mom.stock_id as mom_id,
+        dad.name as dad,
+        dad.stock_id as dad_id
+      FROM {stock} s
+      LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+      LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=s.stock_id
+        AND origcross.type_id = 3684
+      LEFT JOIN {stock_relationship} momr ON momr.object_id=origcross.object_id
+        AND momr.type_id=3632
+      LEFT JOIN {stock_relationship} dadr ON dadr.object_id=origcross.object_id
+        AND dadr.type_id=3633
+      LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
+      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
+
+    $where = [];
+    $joins = [];
+
+    // -- Restrict to RILs.
+    $where[] = 's.type_id=:type_id';
+    $args[':type_id'] = 3967;
+
+    // -- Remove RILL individuals.
+    if(!$filter_results['show_individiuals']) {
+      $where[] = "s.name~*'^[a-z]+-[0-9]+$'";
+    }
+
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "o.genus ~ :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "o.species ~ :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Parents.
+    $this->addParentageQuery($filter_results, $where, $args);
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "(s.name ~* :name OR s.uniquename = :name)";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n",$joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ',$where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY s.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+}

--- a/kp_searches.info
+++ b/kp_searches.info
@@ -7,3 +7,4 @@ dependencies[] = tripal_chado
 dependencies[] = chado_custom_search
 
 files[] = includes/GeneticMarkerSearch.inc
+files[] = includes/GermplasmSearch.inc

--- a/kp_searches.info
+++ b/kp_searches.info
@@ -5,7 +5,3 @@ package = Chado Custom Search
 dependencies[] = tripal
 dependencies[] = tripal_chado
 dependencies[] = chado_custom_search
-
-files[] = includes/GeneticMarkerSearch.inc
-files[] = includes/GermplasmSearch.inc
-files[] = includes/BreedingCrossSearch.inc

--- a/kp_searches.info
+++ b/kp_searches.info
@@ -8,3 +8,4 @@ dependencies[] = chado_custom_search
 
 files[] = includes/GeneticMarkerSearch.inc
 files[] = includes/GermplasmSearch.inc
+files[] = includes/BreedingCrossSearch.inc

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -17,6 +17,7 @@
 
    // EXAMPLE: $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
    $searches['GeneticMarkerSearch'] = 'Genetic Marker Search';
+   $searches['GermplasmSearch'] = 'Germplasm Search';
 
    return $searches;
  }
@@ -25,6 +26,59 @@
  * Save options used in search form using variable_get/set().
  */
 function kp_searches_cache_options() {
+
+  // Crops.
+  //-------------------------
+  // These are hard-coded since we do not want the full list of organisms.
+  $crop_options = [
+    'Cicer' => [
+      'title' => 'Chickpea',
+      'genus' => 'Cicer',
+      'crop-species' => 'arietinum',
+      'image' => '/sites/all/modules/custom/kp_frontpage/images/kphome/crops-chickpea.jpg',
+    ],
+    'Lens' => [
+      'title' => 'Lentil',
+      'genus' => 'Lens',
+      'crop-species' => 'culinaris',
+      'image' => '/sites/all/modules/custom/kp_frontpage/images/kphome/crops-cultivated-lentil.jpg',
+    ],
+    'Phaseolus' => [
+      'title' => 'Dry Bean',
+      'genus' => 'Phaseolus',
+      'crop-species' => 'vulgaris',
+      'image' => '/sites/all/modules/custom/kp_frontpage/images/kphome/crops-dry-bean.jpg',
+    ],
+    'Vicia' => [
+      'title' => 'Faba Bean',
+      'genus' => 'Vicia',
+      'crop-species' => 'faba',
+      'image' => '/sites/all/modules/custom/kp_frontpage/images/kphome/crops-faba-bean.jpg',
+    ],
+    'Pisum' => [
+      'title' => 'Field Pea',
+      'genus' => 'Pisum',
+      'crop-species' => 'sativum',
+      'image' => '/sites/all/modules/custom/kp_frontpage/images/kphome/crops-pea.jpg',
+    ],
+  ];
+  // Now add in the rest of the species.
+  $sql = 'SELECT genus, species FROM {organism} ORDER BY genus, species';
+  $resource = chado_query($sql);
+  foreach ($resource as $r) {
+    if (isset($crop_options[ $r->genus ])) {
+      $crop_options[ $r->genus ]['species'][ $r->species ] = $r->species;
+    }
+  }
+  variable_set('kp_searches_crop_options', serialize($crop_options));
+
+  // Germplasm Types.
+  //-------------------------
+  $options = db_query("SELECT cb.type_id, tb.label
+    FROM chado_bundle cb
+    LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id
+    WHERE cb.data_table = 'stock'")->fetchAllKeyed(0,1);
+  variable_set('kp_searches_germplasm_type_options', serialize($options));
 
   //-------------------------
   // Genetic Marker Types.

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -10,6 +10,7 @@ require_once 'includes/GeneticMarkerSearch.inc';
 require_once 'includes/GermplasmSearch.inc';
 require_once 'includes/BreedingCrossSearch.inc';
 require_once 'includes/CultivarSearch.inc';
+require_once 'includes/RILSearch.inc';
 
  /**
   * Implement hook_chado_custom_search().
@@ -25,6 +26,7 @@ require_once 'includes/CultivarSearch.inc';
    $searches['GermplasmSearch'] = 'Germplasm Search';
    $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
    $searches['CultivarSearch'] = 'Cultivar Search';
+   $searches['RILSearch'] = 'Recombinant Inbred Line (RIL) Search';
 
    return $searches;
  }

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -30,6 +30,22 @@ require_once 'includes/CultivarSearch.inc';
  }
 
 /**
+ * Implements hook_menu().
+ */
+function kp_searches_menu() {
+  $items = [];
+
+  $items['search/germplasm/autocomplete.json/%/%/%'] = array(
+    'page callback' => 'autocomplete_kp_searches_germplasm_name',
+    'page arguments' => array(3,4,5),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
  * Save options used in search form using variable_get/set().
  */
 function kp_searches_cache_options() {
@@ -125,4 +141,53 @@ function kp_searches_cache_options() {
   // -- Finally, Save the options!
   variable_set('kp_searches_marker_types', serialize($marker_types));
 
+}
+
+/**
+ * AUTOCOMPLETE: Germplasm Names respecting access of the user.
+ */
+function autocomplete_kp_searches_germplasm_name($genus, $type_id = 'all', $keyword = '') {
+  global $user;
+
+  $where = [
+      '(s.name~*:keyword OR s.uniquename~*:keyword)',
+      'o.genus = :genus'];
+  $args = [':genus' => $genus, ':keyword' => $keyword];
+
+  // Restrict by type (if supplied).
+  if (is_numeric($type_id)) {
+    $where[] = 's.type_id = :type_id';
+    $args[':type_id'] = $type_id;
+  }
+
+  // Retrict by access.
+  // Only use access control for non administrators. This is put in place to
+  // allow administrators to see content "on the cutting room floor"
+  // (i.e. not of any given type).
+  $administrator = array_search('administrator', $user->roles);
+  if (!$administrator) {
+    // See https://github.com/tripal/tripal/blob/7.x-3.x/tripal/includes/tripal.entity.inc#L495
+    $entity_types = db_query("SELECT cb.type_id, cb.bundle_id FROM chado_bundle cb
+      WHERE cb.data_table = 'stock'")->fetchAllKeyed(0,1);
+    // Only includes bundles the current user has access to.
+    $available_types = [];
+    foreach($entity_types as $type_id => $bundle_id) {
+      $bundle_name = 'bio_data_' . $bundle_id;
+      if (user_access('view ' . $bundle_name)) {
+        $available_types[] = $type_id;
+      }
+    }
+    $where[] = 's.type_id IN (:access_type_ids)';
+    $args[':access_type_ids'] = $available_types;
+  }
+
+  $results = chado_query('SELECT s.name
+    FROM {stock} s
+    LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+    WHERE ' . implode(' AND ', $where)
+    . ' LIMIT 10',
+    $args)->fetchAllKeyed(0,0);
+
+  // Return the results.
+  drupal_json_output($results);
 }

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -6,6 +6,11 @@
  * This file will not include the searches themselves.
  */
 
+require_once 'includes/GeneticMarkerSearch.inc';
+require_once 'includes/GermplasmSearch.inc';
+require_once 'includes/BreedingCrossSearch.inc';
+require_once 'includes/CultivarSearch.inc';
+
  /**
   * Implement hook_chado_custom_search().
   *
@@ -19,6 +24,7 @@
    $searches['GeneticMarkerSearch'] = 'Genetic Marker Search';
    $searches['GermplasmSearch'] = 'Germplasm Search';
    $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
+   $searches['CultivarSearch'] = 'Cultivar Search';
 
    return $searches;
  }

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -18,6 +18,7 @@
    // EXAMPLE: $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
    $searches['GeneticMarkerSearch'] = 'Genetic Marker Search';
    $searches['GermplasmSearch'] = 'Germplasm Search';
+   $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
 
    return $searches;
  }


### PR DESCRIPTION
Provides the following searches:
 - Germplasm: `search/germplasm/all`
 - Breeding Crosses: `search/germplasm/crosses`
 - Registered Varieties: `search/germplasm/varieties`
 - RILs: `search/germplasm/RILs`

## Setup
(done on Fresh)
1. Install or update `chado_search_api` and `kp_searches`. Make sure kp_searches is on this branch.
2. Update `kp_views`. Got to Structure > Views and 
  - disable the following: 
<img width="1619" alt="Screen Shot 2019-08-22 at 12 26 38 PM" src="https://user-images.githubusercontent.com/1566301/63539798-1ffa7b00-c4d8-11e9-9b54-4baef853ac5f.png">

  - delete/disable `F1_search`, `Recombinant_Inbred_Line_search`, `Registered_Variety_search`

3. Clear the cache using `drush cc all` and update the option cache by running `drush php-eval "kp_searches_cache_options();"`
4. Update menu items under Germplasm to point to the new searches.

# Testing
1. Check all the above searches display without errors.
2. Submit search without any filter criteria: check speed and 1st page of results
3. Check pager
4. Check various combinations of filter criteria
5. Ensure that when logged out you can only see the varieties and germplasm search. Also in the germplasm search all results should be of type variety or accession.
6. Check that links to content work.
7. Evaluate general ease of using the searches and if they are intuitive.