### PR TITLE
Variant & Experiment searches

### DIFF
--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -21,6 +21,54 @@
 }
 
 /**
+ * Item list searches.
+ */
+#chado-custom-search-form ul {
+  padding-left: 0px;
+}
+#chado-custom-search-form ul li {
+  border-top: 1px solid #d0d0d0;
+  list-style: none;
+}
+#chado-custom-search-form ul li .result-row {
+  width: 100%;
+  height: 100px;
+  display: inline-flex;
+  justify-content: space-between;
+  margin: 10px 0px;
+}
+#chado-custom-search-form ul li .result-row .result-left {
+  width: 85%;
+}
+#chado-custom-search-form ul li .result-row .result-right {
+  width: 14%;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  font-weight: bold;
+  color: #666666;
+}
+#chado-custom-search-form ul li .result-title {
+  font-size: 1.1em;
+  font-weight: bold;
+  word-wrap: break-word;
+}
+#chado-custom-search-form ul li .result-genus {
+  background-repeat: no-repeat;
+  padding-left: 25px;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAABNElEQVQ4jeXTvyvFURjH8ZeULiKLwY9BTJYbo1L3jxApSSExGZSSQZKFkmKVRfmx2JTBcEshyeQfkE0USga5hu/51tc3bn4NyqfOcM7ned7nOec5hz+kLmxhB3PIoaxYQgYlH3hZPKOQGvliwHmcYgN9qd1734EVQuyHGkkFb6M0ePV4TPkPaC4GbMJTIuEeVcEbxCGug/eEgWKwWOsJ4FJYm8UeqsOm3Wj7DAwq0YNpjGIYFwH2Y+VF95T9DVgGN1hNrTeg5jvASbyIuhtrDHe4xAwqYqNFdDebOMExxhOJ1aG6XdRhAiu49fbZnKEVFr3/SDsDsC/Mj7CGfjSKOp2MP0dHXEVO1L1kwFTw4vkCyhOVt+MA+6KfUyql2nDsKywHyFAC+G3Fv6EiVfGv6R8Cv6RXU4NiJ/enec4AAAAASUVORK5CYII=');
+}
+#chado-custom-search-form ul li .result-category {
+  background-repeat: no-repeat;
+  padding-left: 25px;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAABGklEQVQ4jaXUSysFUQDA8d/NRpSFDXk/1sqCK8XORjZk4/VNKCVLirJQivIdLK0QK69uJBvfQ8lizqkxzdzH+NdZzGnmN+fMTEPrTWGxxHWF3WP2v8g8PlDDN97DOEalDPaMwXB8gb0AnYTRNJrFoANf6E6hR2WxTlzjBzthriLZfssYrOABt/hMzdcaYS85GIzgDWe4yoAz2C3ChurccAhLaM+AC5LnWYgNYLIOHBsNq/4D5q2sH09hK/Ww13DOAbZhLoNVcI4uDAe0moONpbB9XKINVnEXgNgablLoIyaawWJbkk+hCO1DbwarFmGxzRSQRk9zVtYQi23koKWxeuh4WSwPjdh0WSy2Lnn7EevBYVkstiz55TfdL0JZSInMoeXyAAAAAElFTkSuQmCC');
+}
+#chado-custom-search-form ul li .result-year {
+  background-repeat: no-repeat;
+  padding-left: 25px;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAABXUlEQVQ4jZ3UPU4cQRAF4G+RBpnUR0Ag584QIrUEJGyOWeAKDkngAJDDIXwBgwgRPzEhPxJzD4Kq1o6HndmBJ7XU01X1pqvqVTMbFca4wC1ec93m2Th9BmEbD6jnrPv07cQIJ42Af/iN5bxNlfs9XDb8TjL2AwrZE3a7nBo/n+A5Y45npVnI1vrSaGE9Y2pslcPKtGa7HYE1/nTYJmm/Sy5j05p1pdlHOMJV+uwQMqhFA7rQRwj76XNOaKsWHfwq4Ur63BCCrfULdR7hYvq8fIbwGj+HEA5J+Zfo4htO8b1lX9VIuTRlr4cQlnAkMnr0fxMPNJpSZHOpfzoKfuAvzvJ7QUs2lRj0Woh0CEb4lvtDLWEzHb1nMU5DsSEaUWOzbWw+DhP96S/kzQrZ8SynURrKs3QlJmBFyGJRdPPAtGaFrLf2W6Ie8x7Yu1lpdqESHTsX2nrJdZNnOzoG4R2XfnQaJSNtsQAAAABJRU5ErkJggg==');
+}
+
+/**
  * Genetic Marker Search.
  */
 #chado-custom-search-form .seq-range-element .form-type-textfield label {

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -32,7 +32,6 @@
 }
 #chado-custom-search-form ul li .result-row {
   width: 100%;
-  height: 100px;
   display: inline-flex;
   justify-content: space-between;
   margin: 10px 0px;
@@ -47,6 +46,10 @@
   padding-bottom: 15px;
   font-weight: bold;
   color: #666666;
+}
+#chado-custom-search-form ul li .result-row .result-right div {
+  font-size: 12px;
+  padding-bottom: 2px;
 }
 #chado-custom-search-form ul li .result-title {
   font-size: 1.1em;

--- a/css/all_kp_searches.css
+++ b/css/all_kp_searches.css
@@ -39,6 +39,7 @@
 }
 #chado-custom-search-form ul li .result-row .result-left {
   width: 85%;
+  overflow-y: hidden;
 }
 #chado-custom-search-form ul li .result-row .result-right {
   width: 14%;

--- a/includes/ExperimentSearch.inc
+++ b/includes/ExperimentSearch.inc
@@ -264,10 +264,17 @@ class ExperimentSearch extends KPSEARCH {
             <div class="result-title">'.$title.'</div>
             <div class="result-description">'.$description.'</div>
           </div>
-          <div class="result-right">
-            <div class="result-year" title="Year(s) of Funding">'.$r->year.'</div>
-            <div class="result-genus" title="Genus for germplasm">'.$r->genus.'</div>
-            <div class="result-category" title="Research Category">'.$r->category.'</div>
+	  <div class="result-right">';
+      if ($r->year) {
+        $markup .= '<div class="result-year" title="Year(s) of Funding">'.$r->year.'</div>';
+      }
+      if ($r->genus) {
+        $markup .= '<div class="result-genus" title="Genus for germplasm">'.$r->genus.'</div>';
+      }
+      if ($r->category) {
+        $markup .= '<div class="result-category" title="Research Category">'.$r->category.'</div>';
+      }
+      $markup .= '
           </div>
         </div>';
       $list[] = $markup;

--- a/includes/ExperimentSearch.inc
+++ b/includes/ExperimentSearch.inc
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Provides a search for chado featuremap-based Tripal Content.
+ *
+ */
+class ExperimentSearch extends KPSEARCH {
+
+  /**
+   * The human readable title of this search. This will be used in listings
+   * and shown on the search page as the title.
+   */
+  public static $title = 'Experiment Search';
+
+  /**
+   * The machine name of the module providing this search.
+   */
+  public static $module = 'kp_searches';
+
+  /**
+   * A description of this search. This is shown at the top of the search page
+   * and used for the menu item.
+   */
+  public static $description = '';
+
+  /**
+   * The machine names of the permissions with access to this search. This is
+   * used to map your search to existing permissions. It must be an array and
+   * is used in hook_menu(). Some examples include 'access content'
+   * and 'administer tripal'.
+   */
+  public static $permissions = ['access content'];
+
+  /**
+   * If TRUE, this search will require the submit button to be clicked before
+   * executing the query; whereas, if FALSE it will be executed on the
+   * first page load without parameters.
+   *
+   * NOTE: to control the results without parameters check $this->submitted
+   * in getQuery() and if FALSE return your pre-submit query.
+   */
+  public static $require_submit = FALSE;
+
+  /**
+   * Add a pager to search results
+   * with $num_items_per_page results on a single page.
+   * NOTE: Your query has to handle paging.
+   */
+  public static $pager = TRUE;
+  public static $num_items_per_page = 50;
+
+  /**
+   * This defined the hook_menu definition for this search. At a minimum the
+   * path is required.
+   */
+  public static $menu = [
+    'path' => 'research/projects',
+    // @todo support menu items.
+  ];
+
+  /**
+   * Add CSS/JS to the form/results page.
+   * NOTE: paths supplied should be relative to $module.
+   */
+  public static $attached = [
+    'css' => [
+      'css/all_kp_searches.css',
+    ],
+    'js' => [],
+  ];
+
+  /**
+   * Information regarding the fields and filters for this search.
+   */
+  public static $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'project',
+          'id_column' => 'project_id'
+        ],
+      ],
+      'genus' => [
+        'title' => 'Genus',
+      ],
+      'year' => [
+        'title' => 'Dates',
+      ],
+      'category' => [
+        'title' => 'Category',
+      ],
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume species the experiment is focused on (e.g. Lens culinaris).',
+        'default' => 'Lens',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => '',
+      ],
+      'year' => [
+        'title' => 'Year',
+        'help' => 'The years the project is ongoing for.',
+      ],
+      'category' => [
+        'title' => 'Category',
+        'help' => 'The category of the experiment.',
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name of the experiment you are interested in (partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Text that should appear on the button at the bottom of the importer
+   * form.
+   */
+  public static $button_text = 'Search';
+
+  /**
+   * Generate the filter form.
+   *
+   * The base class will generate textfields for each filter defined in $info,
+   * set defaults, labels and descriptions, as well as, create the search
+   * button.
+   *
+   * Extend this method to alter the filter form.
+   */
+  public function form($form, $form_state) {
+    $form = parent::form($form, $form_state);
+
+    // Add a crop selector.
+    $this->addCropFormElement($form, $form_state);
+
+    // Add a Scientific name selector.
+    $this->addSpeciesFormElement($form, $form_state);
+
+    // @todo: add species to the database in a consistent manner.
+    $form['scientific_name']['species']['#disabled'] = TRUE;
+
+    return $form;
+  }
+
+  /**
+   * Allows custom searches to validate the form results.
+   * Use form_set_error() to signal invalid values.
+   */
+  public function validateForm($form, $form_state) {
+    //$values = $form_state['values'];
+  }
+
+  /**
+   * Determine the query for the genetic marker search.
+   *
+   * @param string $query
+   *   The full SQL query to execute. This will be executed using chado_query()
+   *   so use curly brackets appropriately. Use :placeholders for any values.
+   * @param array $args
+   *   An array of arguments to pass to chado_query(). Keys must be the
+   *   placeholders in the query and values should be what you want them set to.
+   */
+  public function getQuery(&$query, &$args, $offset) {
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+    // @debug dpm($filter_results, '$filter_results');
+
+    // @todo Collaborators: 5311
+    $query = "
+      SELECT
+        exp.name, exp.project_id,
+        exp.description,
+        genus.value as genus,
+        yr.value as year,
+        cat.value as category
+      FROM {project} exp
+      LEFT JOIN {projectprop} genus ON genus.project_id=exp.project_id
+        AND genus.type_id IN (SELECT cvterm_id FROM {cvterm} WHERE name='genus')
+      LEFT JOIN {projectprop} yr ON yr.project_id=exp.project_id
+        AND yr.type_id=6364 AND yr.rank=0
+      LEFT JOIN {projectprop} cat ON cat.project_id=exp.project_id
+        AND cat.type_id=6365 AND cat.rank=0
+      LEFT JOIN {projectprop} re ON re.project_id=exp.project_id
+        AND re.type_id=4310 AND re.rank=0";
+
+    $where = [];
+    $joins = [];
+
+    $where[] = "re.value = :content_type";
+    $args[':content_type'] = 'Research Experiment';
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "genus.value ~* :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "species.value ~* :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "exp.name ~ :name";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n",$joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ',$where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY exp.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+
+  /**
+   * Format the results within the $form array.
+   *
+   * The base class will format the results as a table.
+   *
+   * @param array $form
+   *   The current form array.
+   * @param array $results
+   *   The results to format. This will be an array of standard objects where
+   *   the keys map to the keys in $info['fields'].
+   */
+  public function formatResults(&$form, $results) {
+    $list = [];
+
+    foreach ($results as $r) {
+      // Add a link to the title.
+      $title = $r->name;
+      $id = NULL;
+      if ($r->project_id) {
+        $id = chado_get_record_entity_by_table('project', $r->project_id);
+        if ($id) {
+          $title = l($r->name, 'bio_data/'.$id);
+        }
+      }
+
+      // Substring the description.
+      $description = strip_tags($r->description);
+      if (preg_match('/^.{1,500}\b/s', $description, $match)) {
+        $description = trim($match[0]);
+      }
+      if ($id) {
+        $description .= ' ' . l('[Read more]', 'bio_data/'.$id);
+      }
+
+      $markup = '
+        <div class="result-row">
+          <div class="result-left">
+            <div class="result-title">'.$title.'</div>
+            <div class="result-description">'.$description.'</div>
+          </div>
+          <div class="result-right">
+            <div class="result-year">'.$r->year.'</div>
+            <div class="result-genus">'.$r->genus.'</div>
+            <div class="result-category">'.$r->category.'</div>
+          </div>
+        </div>';
+      $list[] = $markup;
+    }
+
+    $form['results'] = [
+      '#theme' => 'item_list',
+      '#items' => $list,
+      '#type' => 'ul',
+      '#weight' => 50,
+    ];
+
+    return $form;
+  }
+}

--- a/includes/ExperimentSearch.inc
+++ b/includes/ExperimentSearch.inc
@@ -251,10 +251,10 @@ class ExperimentSearch extends KPSEARCH {
 
       // Substring the description.
       $description = strip_tags($r->description);
-      if (preg_match('/^.{1,500}\b/s', $description, $match)) {
+      if (preg_match('/^.{1,300}\b/s', $description, $match)) {
         $description = trim($match[0]);
       }
-      if ($id) {
+      if ($id && (strlen($description) > 0)){
         $description .= ' ' . l('[Read more]', 'bio_data/'.$id);
       }
 
@@ -265,9 +265,9 @@ class ExperimentSearch extends KPSEARCH {
             <div class="result-description">'.$description.'</div>
           </div>
           <div class="result-right">
-            <div class="result-year">'.$r->year.'</div>
-            <div class="result-genus">'.$r->genus.'</div>
-            <div class="result-category">'.$r->category.'</div>
+            <div class="result-year" title="Year(s) of Funding">'.$r->year.'</div>
+            <div class="result-genus" title="Genus for germplasm">'.$r->genus.'</div>
+            <div class="result-category" title="Research Category">'.$r->category.'</div>
           </div>
         </div>';
       $list[] = $markup;

--- a/includes/ExperimentSearch.inc
+++ b/includes/ExperimentSearch.inc
@@ -104,14 +104,6 @@ class ExperimentSearch extends KPSEARCH {
         'title' => 'Species',
         'help' => '',
       ],
-      'year' => [
-        'title' => 'Year',
-        'help' => 'The years the project is ongoing for.',
-      ],
-      'category' => [
-        'title' => 'Category',
-        'help' => 'The category of the experiment.',
-      ],
       'name' => [
         'title' => 'Name',
         'help' => 'The name of the experiment you are interested in (partial names are accepted).',

--- a/includes/GeneticMarkerSearch.inc
+++ b/includes/GeneticMarkerSearch.inc
@@ -85,6 +85,9 @@ class GeneticMarkerSearch extends KPSEARCH {
       'type' => [
         'title' => 'Marker Type',
       ],
+      'original_loc' => [
+        'title' => 'Original Location',
+      ],
       'species' => [
         'title' => 'Source Species',
         'entity_link' => [
@@ -240,9 +243,15 @@ class GeneticMarkerSearch extends KPSEARCH {
     // @debug dpm($filter_results, '$filter_results');
 
     $query = "
-      SELECT marker.feature_id, marker.name as name, type.value as type, o.organism_id, o.genus||' '||o.species as species
+      SELECT
+        marker.feature_id, marker.name as name,
+        type.value as type,
+        olocparent.name||':'||original_loc.fmin||'..'||original_loc.fmax as original_loc,
+        o.organism_id, o.genus||' '||o.species as species
       FROM {feature} marker
       LEFT JOIN {organism} o ON o.organism_id=marker.organism_id
+      LEFT JOIN {featureloc} original_loc ON original_loc.feature_id = marker.feature_id AND original_loc.locgroup=0
+      LEFT JOIN {feature} olocparent ON olocparent.feature_id=original_loc.srcfeature_id
       LEFT JOIN {featureprop} type ON type.feature_id = marker.feature_id
         AND type.type_id IN
           (SELECT cvterm_id FROM chado.cvterm WHERE name='additionalType') ";

--- a/includes/SequenceVariantSearch.inc
+++ b/includes/SequenceVariantSearch.inc
@@ -85,6 +85,9 @@ class SequenceVariantSearch extends KPSEARCH {
       'type' => [
         'title' => 'Variant Type',
       ],
+      'original_loc' => [
+        'title' => 'Original Location',
+      ],
       'species' => [
         'title' => 'Source Species',
         'entity_link' => [
@@ -240,9 +243,15 @@ class SequenceVariantSearch extends KPSEARCH {
     // @debug dpm($filter_results, '$filter_results');
 
     $query = "
-      SELECT variant.feature_id, variant.name as name, type.value as type, o.organism_id, o.genus||' '||o.species as species
+      SELECT
+        variant.feature_id, variant.name as name,
+        type.value as type,
+        olocparent.name||':'||original_loc.fmin||'..'||original_loc.fmax as original_loc,
+        o.organism_id, o.genus||' '||o.species as species
       FROM {feature} variant
       LEFT JOIN {organism} o ON o.organism_id=variant.organism_id
+      LEFT JOIN {featureloc} original_loc ON original_loc.feature_id = variant.feature_id AND original_loc.locgroup=0
+      LEFT JOIN {feature} olocparent ON olocparent.feature_id=original_loc.srcfeature_id
       LEFT JOIN {featureprop} type ON type.feature_id = variant.feature_id
         AND type.type_id IN
           (SELECT cvterm_id FROM chado.cvterm WHERE name='additionalType') ";

--- a/includes/SequenceVariantSearch.inc
+++ b/includes/SequenceVariantSearch.inc
@@ -1,0 +1,317 @@
+<?php
+
+/**
+ * Provides a search for SO:sequence_variant chado feature-based Tripal Content.
+ *
+ */
+class SequenceVariantSearch extends KPSEARCH {
+
+  /**
+   * The human readable title of this search. This will be used in listings
+   * and shown on the search page as the title.
+   */
+  public static $title = 'Sequence Variant Search';
+
+  /**
+   * The machine name of the module providing this search.
+   */
+  public static $module = 'kp_searches';
+
+  /**
+   * A description of this search. This is shown at the top of the search page
+   * and used for the menu item.
+   */
+  public static $description = 'While the term variant refers to a position in the genome with variation, genetic marker refers specifically to an assay which samples that variation.';
+
+  /**
+   * The machine names of the permissions with access to this search. This is
+   * used to map your search to existing permissions. It must be an array and
+   * is used in hook_menu(). Some examples include 'access content'
+   * and 'administer tripal'.
+   */
+  public static $permissions = ['access content'];
+
+  /**
+   * If TRUE, this search will require the submit button to be clicked before
+   * executing the query; whereas, if FALSE it will be executed on the
+   * first page load without parameters.
+   *
+   * NOTE: to control the results without parameters check $this->submitted
+   * in getQuery() and if FALSE return your pre-submit query.
+   */
+  public static $require_submit = TRUE;
+
+  /**
+   * Add a pager to search results
+   * with $num_items_per_page results on a single page.
+   * NOTE: Your query has to handle paging.
+   */
+  public static $pager = TRUE;
+  public static $num_items_per_page = 50;
+
+  /**
+   * This defined the hook_menu definition for this search. At a minimum the
+   * path is required.
+   */
+  public static $menu = [
+    'path' => 'search/variants',
+    // @todo support menu items.
+  ];
+
+  /**
+   * Add CSS/JS to the form/results page.
+   * NOTE: paths supplied should be relative to $module.
+   */
+  public static $attached = [
+    'css' => [
+      'css/all_kp_searches.css',
+    ],
+    'js' => [],
+  ];
+
+  /**
+   * Information regarding the fields and filters for this search.
+   */
+  public static $info = [
+    // Lists the columns in your results table.
+    'fields' => [
+      'name' => [
+        'title' => 'Name',
+        'entity_link' => [
+          'chado_table' => 'feature',
+          'id_column' => 'feature_id'
+        ],
+      ],
+      'type' => [
+        'title' => 'Variant Type',
+      ],
+      'species' => [
+        'title' => 'Source Species',
+        'entity_link' => [
+          'chado_table' => 'organism',
+          'id_column' => 'organism_id'
+        ],
+      ],
+    ],
+    // The filter criteria available to the user.
+    // This is used to generate a search form which can be altered.
+    'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The legume species the Sequence Variant was designed for (e.g. Lens culinaris).',
+      ],
+      'species' => [
+        'title' => 'Species',
+        'help' => '',
+      ],
+      'type' => [
+        'title' => 'Variant Type',
+        'help' => 'The type of variant you are interested in (e.g. SNP).',
+        //'default' => 'Exome Capture',
+      ],
+      'project' => [
+        'title' => 'Experiment',
+        'help' => 'The experiment you are interested in (e.g. AGILE; partial names are accepted).',
+      ],
+      'start-backbone' => [
+        'title' => 'Start: Backbone',
+        'help' => 'The name of the sequence the variants are located on.'
+      ],
+      'start-pos' => [
+        'title' => 'Start: Position',
+        'help' => 'The numeric start position of the range you are interested in.'
+      ],
+      'end-pos' => [
+        'title' => 'End: Position',
+        'help' => 'The numeric end position of the range you are interested in.'
+      ],
+      'name' => [
+        'title' => 'Name',
+        'help' => 'The name or accession of the variant (e.g. LcC00002p390; partial names are accepted).',
+      ],
+    ],
+  ];
+
+  /**
+   * Text that should appear on the button at the bottom of the importer
+   * form.
+   */
+  public static $button_text = 'Search';
+
+  /**
+   * Generate the filter form.
+   *
+   * The base class will generate textfields for each filter defined in $info,
+   * set defaults, labels and descriptions, as well as, create the search
+   * button.
+   *
+   * Extend this method to alter the filter form.
+   */
+  public function form($form, $form_state) {
+    $form = parent::form($form, $form_state);
+
+    // Add a crop selector.
+    $this->addCropFormElement($form, $form_state);
+
+    // Add a Scientific name selector.
+    $this->addSpeciesFormElement($form, $form_state);
+
+    // Make the variant type a drop-down.
+    $options = unserialize(variable_get('kp_searches_variant_types', 'a:0{}'));
+    $form['type']['#type'] = 'select';
+    $form['type']['#options'] = $options;
+    $form['type']['#empty_option'] = ' - Select -';
+
+    // Make the project an autocomplete.
+    // DEPENDENCY: nd_genotypes.
+    $form['project']['#autocomplete_path'] = 'tripal_ajax/nd_genotypes/project/name';
+
+    // Add a sequence range element.
+    $description = 'The range of the genome you would like to display variants from.';
+    $form['seq_range'] = array(
+      '#type' => 'markup',
+      '#prefix' => '<div class="seq-range-element form-item"><label>Genome Range</label>',
+      '#suffix' => '<div class="description">' . $description . '</div></div>',
+    );
+    // Group the sequence range elements.
+    $form['seq_range']['start-label'] = [
+      '#type' => 'item',
+      '#markup' => 'From',
+    ];
+    $form['seq_range']['start-backbone'] = $form['start-backbone'];
+    $form['seq_range']['start-backbone']['#attributes']['placeholder'] = 'Sequence Name';
+    unset($form['start-backbone']);
+    $form['seq_range']['start-pos'] = $form['start-pos'];
+    $form['seq_range']['start-pos']['#attributes']['placeholder'] = 'Start Position';
+    unset($form['start-pos']);
+    $form['seq_range']['end-label'] = [
+      '#type' => 'item',
+      '#markup' => 'to',
+    ];
+    $form['seq_range']['end-pos'] = $form['end-pos'];
+    $form['seq_range']['end-pos']['#attributes']['placeholder'] = 'End Position';
+    unset($form['end-pos']);
+
+    return $form;
+  }
+
+  /**
+   * Allows custom searches to validate the form results.
+   * Use form_set_error() to signal invalid values.
+   */
+  public function validateForm($form, $form_state) {
+    $values = $form_state['values'];
+
+    // If any of the range elements are filled out...
+    if ($values['start-backbone'] != ''
+      OR $values['start-pos'] != ''
+      OR $values['end-pos'] != '') {
+
+      // Then they all need to be!
+      if ($values['start-backbone'] == '') {
+        form_set_error('start-backbone',
+          'Genome Range: The sequence name is required.');
+      }
+      if ($values['start-pos'] == '') {
+        form_set_error('start-pos',
+          'Genome Range: The range start position is required.');
+      }
+      if ($values['end-pos'] == '') {
+        form_set_error('end-pos',
+          'Genome Range: The range end position is required.');
+      }
+    }
+  }
+
+  /**
+   * Determine the query for the Sequence Variant search.
+   *
+   * @param string $query
+   *   The full SQL query to execute. This will be executed using chado_query()
+   *   so use curly brackets appropriately. Use :placeholders for any values.
+   * @param array $args
+   *   An array of arguments to pass to chado_query(). Keys must be the
+   *   placeholders in the query and values should be what you want them set to.
+   */
+  public function getQuery(&$query, &$args, $offset) {
+
+    // Retrieve the filter results already set.
+    $filter_results = $this->values;
+    // @debug dpm($filter_results, '$filter_results');
+
+    $query = "
+      SELECT variant.feature_id, variant.name as name, type.value as type, o.organism_id, o.genus||' '||o.species as species
+      FROM {feature} variant
+      LEFT JOIN {organism} o ON o.organism_id=variant.organism_id
+      LEFT JOIN {featureprop} type ON type.feature_id = variant.feature_id
+        AND type.type_id IN
+          (SELECT cvterm_id FROM chado.cvterm WHERE name='additionalType') ";
+
+    $where = ["variant.type_id IN (SELECT cvterm_id FROM {cvterm} WHERE name='sequence_variant')"];
+    $joins = [];
+
+    // -- Genus.
+    if ($filter_results['genus'] != '') {
+      $where[] = "o.genus ~* :genus";
+      $args[':genus'] = $filter_results['genus'];
+    }
+
+    // -- Species.
+    if ($filter_results['species'] != '') {
+      $where[] = "o.species ~* :species";
+      $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Type.
+    if ($filter_results['type'] != '') {
+      $where[] = "type.value ~ :type";
+      $args[':type'] = $filter_results['type'];
+    }
+
+    // -- Project.
+    if ($filter_results['project'] != '') {
+      $where[] = "project.name ~ :project";
+      $args[':project'] = $filter_results['project'];
+      $joins[] = 'LEFT JOIN {project_feature} pf ON pf.feature_id=variant.feature_id';
+      $joins[] = 'LEFT JOIN {project} project ON project.project_id=pf.project_id';
+    }
+
+    // -- Name.
+    if ($filter_results['name'] != '') {
+      $where[] = "(variant.name ~ :name OR variant.uniquename = :name)";
+      $args[':name'] = $filter_results['name'];
+    }
+
+    // -- Genome Range.
+    if ($filter_results['start-pos'] != ''
+      AND $filter_results['end-pos'] != '') {
+
+        $joins[] = 'LEFT JOIN {featureloc} loc
+          ON loc.feature_id=variant.feature_id';
+        $where[] = 'loc.fmin BETWEEN :start AND :end';
+        $args[':start'] = $filter_results['start-pos'];
+        $args[':end'] = $filter_results['end-pos'];
+        $where[] = 'loc.srcfeature_id IN
+          (SELECT feature_id FROM {feature}
+          WHERE name=:backbone OR uniquename=:backbone)';
+        $args[':backbone'] = $filter_results['start-backbone'];
+    }
+
+    // Finally, add it to the query.
+    if (!empty($joins)) {
+      $query .= implode("\n",$joins);
+    }
+    if (!empty($where)) {
+      $query .= "\n" . ' WHERE ' . implode(' AND ',$where);
+    }
+
+    // Sort even though it is SLOW b/c ppl expect it.
+    $query .= "\n" . ' ORDER BY variant.name ASC';
+
+    // Handle paging.
+    $limit = $this::$num_items_per_page + 1;
+    $query .= "\n" . ' LIMIT ' . $limit . ' OFFSET ' . $offset;
+
+    // @debug dpm(strtr(str_replace(['{','}'], ['chado.', ''], $query), $args), 'query');
+  }
+}

--- a/includes/SequenceVariantSearch.inc
+++ b/includes/SequenceVariantSearch.inc
@@ -170,7 +170,7 @@ class SequenceVariantSearch extends KPSEARCH {
     $form['project']['#autocomplete_path'] = 'tripal_ajax/nd_genotypes/project/name';
 
     // Add a sequence range element.
-    $description = 'The range of the genome you would like to display variants from.';
+    $description = 'The range of the genome you would like to display variants from (e.g. LcChr2:1000-50000).';
     $form['seq_range'] = array(
       '#type' => 'markup',
       '#prefix' => '<div class="seq-range-element form-item"><label>Genome Range</label>',

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -17,6 +17,8 @@ require_once 'includes/RILSearch.inc';
 
 require_once 'includes/GeneticMapSearch.inc';
 
+require_once 'includes/ExperimentSearch.inc';
+
  /**
   * Implement hook_chado_custom_search().
   *
@@ -36,6 +38,8 @@ require_once 'includes/GeneticMapSearch.inc';
    $searches['RILSearch'] = 'Recombinant Inbred Line (RIL) Search';
 
    $searches['GeneticMapSearch'] = 'Genetic Map Search';
+
+   $searches['ExperimentSearch'] = 'Experiment Search';
 
    return $searches;
  }

--- a/kp_searches.module
+++ b/kp_searches.module
@@ -8,6 +8,7 @@
 require_once 'includes/KPSEARCH.inc';
 
 require_once 'includes/GeneticMarkerSearch.inc';
+require_once 'includes/SequenceVariantSearch.inc';
 
 require_once 'includes/GermplasmSearch.inc';
 require_once 'includes/BreedingCrossSearch.inc';
@@ -27,6 +28,7 @@ require_once 'includes/GeneticMapSearch.inc';
 
    // EXAMPLE: $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
    $searches['GeneticMarkerSearch'] = 'Genetic Marker Search';
+   $searches['SequenceVariantSearch'] = 'Sequence Variant Search';
 
    $searches['GermplasmSearch'] = 'Germplasm Search';
    $searches['BreedingCrossSearch'] = 'Breeding Cross Search';
@@ -138,17 +140,29 @@ function kp_searches_cache_options() {
   $partitions = chado_query($query)->fetchCol();
   // -- Retieve marker type options for all partitions.
   $marker_types = [];
+  $variant_types = [];
   foreach ($partitions as $partition_name) {
-    $curr_partition_types = variable_get(
+    // Markers:
+    $curr_partition_marker_types = variable_get(
       'nd_genotypes_'.$partition_name.'_marker_types',
       'a:0{}'
     );
-    if (!empty($curr_partition_types)) {
-      $marker_types = array_merge($marker_types, unserialize($curr_partition_types));
+    if (!empty($curr_partition_marker_types)) {
+      $marker_types = array_merge($marker_types, unserialize($curr_partition_marker_types));
+    }
+
+    // Variants:
+    $curr_partition_variant_types = variable_get(
+      'nd_genotypes_'.$partition_name.'_variant_types',
+      'a:0{}'
+    );
+    if (!empty($curr_partition_variant_types)) {
+      $variant_types = array_merge($variant_types, unserialize($curr_partition_variant_types));
     }
   }
   // -- Finally, Save the options!
   variable_set('kp_searches_marker_types', serialize($marker_types));
+  variable_set('kp_searches_variant_types', serialize($variant_types));
 
 }
 


### PR DESCRIPTION
This PR adds the following searches:
 - Experiment/Project: `research/projects`
 - Variant: `search/variants`

## Preparation
To test these searches you will first need to remove the previous views.
1. Go to `admin/structure/views` and search for each view
2. Click on the arrow beside edit and choose disable

## Testing
- The search should appear at the same url as the old view -make sure the link on the frontpage takes you to the new search (after prep is done)
- All filter criteria should work (note for experiments the genus filter is dependant on a property of taxrank:genus. I've added these to portal but they may not be on your clone; species is disabled on experiment search)

## Screenshots
<img width="1028" alt="Screen Shot 2020-04-02 at 7 58 30 PM" src="https://user-images.githubusercontent.com/1566301/78316316-935b7500-751c-11ea-8afe-81bb32bcb9ca.png">
<img width="1013" alt="Screen Shot 2020-04-02 at 8 00 08 PM" src="https://user-images.githubusercontent.com/1566301/78316323-95253880-751c-11ea-83ea-d2d34d7d862b.png">
