### PR TITLE
Filter by collection

### DIFF
--- a/includes/CultivarSearch.inc
+++ b/includes/CultivarSearch.inc
@@ -94,6 +94,9 @@ class CultivarSearch extends GermplasmSearch {
           'id_column' => 'dad_id'
         ],
       ],
+      'collection' => [
+        'title' => 'Collection'
+      ],
       'source_institute' => [
         'title' => 'Source Institute',
       ],
@@ -114,6 +117,10 @@ class CultivarSearch extends GermplasmSearch {
       'species' => [
         'title' => 'Species',
         'help' => 'The legume species the germplasm belongs to (e.g. culinaris).',
+      ],
+      'collection' => [
+        'title' => 'Collection',
+        'help' => 'The collection or population the germplasm is part of.'
       ],
       'source_institute' => [
         'title' => 'Source Institute',
@@ -166,6 +173,9 @@ class CultivarSearch extends GermplasmSearch {
     // Add a Scientific name selector.
     $this->addSpeciesFormElement($form, $form_state);
 
+    // Add collection/population selector.
+    $this->addCollectionFormElement($form, $form_state);
+
     // Add a Maternal/paternal name selector.
     $this->addparentageFormElement($form, $form_state);
 
@@ -212,7 +222,8 @@ class CultivarSearch extends GermplasmSearch {
         mom.name as mom,
         mom.stock_id as mom_id,
         dad.name as dad,
-        dad.stock_id as dad_id
+        dad.stock_id as dad_id,
+        col.name as collection
       FROM {stock} s
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
       LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
@@ -230,7 +241,9 @@ class CultivarSearch extends GermplasmSearch {
       LEFT JOIN {stock_relationship} dadr
         ON (dadr.object_id=origcross.object_id OR dadr.object_id=regcultivar.object_id)
         AND dadr.type_id=3633
-      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id";
+      LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id
+      LEFT JOIN {stockcollection_stock} c ON s.stock_id = c.stock_id 
+      LEFT JOIN {stockcollection} col ON c.stockcollection_id = col.stockcollection_id";
 
     $where = [];
     $joins = [];
@@ -249,6 +262,12 @@ class CultivarSearch extends GermplasmSearch {
     if ($filter_results['species'] != '') {
       $where[] = "o.species ~ :species";
       $args[':species'] = $filter_results['species'];
+    }
+
+    // -- Collection: 0 - select all.
+    if ($filter_results['collection'] > 0) {
+      $where[] = "col.stockcollection_id = :collection";
+      $args[':collection'] = $filter_results['collection'];
     }
 
     // -- Source Institute.

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -128,7 +128,7 @@ class GermplasmSearch extends KPSEARCH {
         'help' => 'The country the seed originated from.'
       ],
       'collection' => [
-        'title' => 'Collection/Population',
+        'title' => 'Collection',
         'help' => 'The collection or population the germplasm is part of.'
       ],
       'source_institute' => [
@@ -293,13 +293,17 @@ class GermplasmSearch extends KPSEARCH {
         s.stock_id,
         tb.label as type,
         origin.value as origin,
-        source.value as source_institute
+        source.value as source_institute,
+        col.name as collection
       FROM {stock} s
       LEFT JOIN {organism} o ON o.organism_id=s.organism_id
       LEFT JOIN {stockprop} source ON source.stock_id=s.stock_id AND source.type_id=3711
       LEFT JOIN {stockprop} origin ON origin.stock_id=s.stock_id AND origin.type_id=3976
       LEFT JOIN chado_bundle cb ON cb.type_id=s.type_id
-      LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id ";
+      LEFT JOIN tripal_bundle tb ON tb.id=cb.bundle_id 
+      LEFT JOIN {stockcollection_stock} c ON s.stock_id = c.stock_id 
+      LEFT JOIN {stockcollection} col ON c.stockcollection_id = col.stockcollection_id
+      ";
 
     $where = [];
     $joins = [];
@@ -332,6 +336,12 @@ class GermplasmSearch extends KPSEARCH {
     if ($filter_results['origin'] != '') {
       $where[] = "origin.value ~* :origin";
       $args[':origin'] = $filter_results['origin'];
+    }
+
+    // -- Collection: 0 - select all.
+    if ($filter_results['collection'] > 0) {
+      $where[] = "col.stockcollection_id = :collection";
+      $args[':collection'] = $filter_results['collection'];
     }
 
     // -- Name.

--- a/includes/GermplasmSearch.inc
+++ b/includes/GermplasmSearch.inc
@@ -94,6 +94,9 @@ class GermplasmSearch extends KPSEARCH {
       'origin' => [
         'title' => 'Origin',
       ],
+      'collection' => [
+        'title' => 'Collection'
+      ],
       'source_institute' => [
         'title' => 'Source Institute',
       ],
@@ -123,6 +126,10 @@ class GermplasmSearch extends KPSEARCH {
       'origin' => [
         'title' => 'Germplasm Origin',
         'help' => 'The country the seed originated from.'
+      ],
+      'collection' => [
+        'title' => 'Collection/Population',
+        'help' => 'The collection or population the germplasm is part of.'
       ],
       'source_institute' => [
         'title' => 'Source Institute',
@@ -170,6 +177,9 @@ class GermplasmSearch extends KPSEARCH {
 
     // Add a Scientific name selector.
     $this->addSpeciesFormElement($form, $form_state);
+
+    // Add collection/population selector.
+    $this->addCollectionFormElement($form, $form_state);
 
     // Change category to a drop-down.
     $options = unserialize(variable_get('kp_searches_germplasm_type_options', 'a:0:{}'));

--- a/includes/KPSEARCH.inc
+++ b/includes/KPSEARCH.inc
@@ -166,6 +166,8 @@ class KPSEARCH extends ChadoCustomSearch {
     $collections = chado_query($sql_collection);    
     if ($collections->rowCount() > 0) {
       foreach($collections as $collection) {
+        // Collection id number - Collection Name: Field will return
+        // collection id number, NOT THE NAME.
         $collection_options[ $collection->id ] = $collection->name;
       }
     }
@@ -173,7 +175,7 @@ class KPSEARCH extends ChadoCustomSearch {
     $q = drupal_get_query_parameters();
     
     // Refine collection options to only collection names
-    // where registered germplasm has the genus selected.
+    // where a registered germplasm has the genus of the selected genus.
     if (isset($q) && is_array($q) && $collection_options) {
       if (isset($q['genus']) && !empty($q['genus'])) {
         $genus = $q['genus'];
@@ -192,7 +194,7 @@ class KPSEARCH extends ChadoCustomSearch {
         $new_collection_options = [0 => $default_text];
         foreach($collection_options as $i => $collection) {
           if ($i > 0) {
-            // Skip default select option.
+            // Skip default select option 0.
 
             $has_genus = chado_query($sql_new_collection, [':genus' => $genus, ':collection' => $i])
               ->fetchObject();
@@ -203,14 +205,18 @@ class KPSEARCH extends ChadoCustomSearch {
           }
         }
       }
+      
+      // Use currently selected collection not the default.
+      $default_collection = $q['collection'];
     }
-
-    $options = (count($new_collection_options) > 0) ? $new_collection_options : $collection_options;
+    
+    $options = (count($new_collection_options) > 1) ? $new_collection_options : $collection_options;
+    $collection_field = $class::$info['filters']['collection'];
 
     $form['collection'] = array(
       '#type' => 'select',
-      '#title' => $class::$info['filters']['collection']['title'],
-      '#description' => $class::$info['filters']['collection']['help'],
+      '#title' => t($collection_field['title']),
+      '#description' => t($collection_field['help']),
       '#options' => $options,
       '#default_value' => $default_collection
     );

--- a/includes/KPSEARCH.inc
+++ b/includes/KPSEARCH.inc
@@ -136,6 +136,7 @@ class KPSEARCH extends ChadoCustomSearch {
     $form['scientific_name']['species']['#options'] = $species;
     $form['scientific_name']['species']['#empty_option'] = '- Select Species -';
     $form['scientific_name']['species']['#default_value'] = $species_default;
+    $form['scientific_name']['species']['#attributes'] = ['onchange' => 'this.form.submit();'];
     unset($form['species']);
   }
 

--- a/includes/KPSEARCH.inc
+++ b/includes/KPSEARCH.inc
@@ -179,24 +179,37 @@ class KPSEARCH extends ChadoCustomSearch {
     if (isset($q) && is_array($q) && $collection_options) {
       if (isset($q['genus']) && !empty($q['genus'])) {
         $genus = $q['genus'];
-        
+        $species = (empty($q['species'])) ? '' : $q['species']; 
+
         // A single stock matching the genus (from collection) would be enough
         // to satisfy that collection has a germplasm with the genus.
         $sql_new_collection = "
           SELECT stock_id AS id FROM {stock} INNER JOIN {organism} USING(organism_id) 
-          WHERE organism.genus = :genus AND stock.stock_id IN 
+          WHERE organism.genus = :genus %s AND stock.stock_id IN 
             (SELECT stock_id FROM {stockcollection_stock} WHERE stockcollection_id = :collection) 
           LIMIT 1
         ";
         
+        // Add filter by species. GENUS + SPECIES.
+        $filter = '';
+        $args = [];
+        if (!empty($species)) {
+          $filter = 'AND organism.species = :species';
+          $args[':species'] = $species;
+        } 
+
+        $sql_new_collection = sprintf($sql_new_collection, $filter);
+
         // When user starts selecting filters... prepare
         // collection field and suggest relevant to selections.
         $new_collection_options = [0 => $default_text];
         foreach($collection_options as $i => $collection) {
           if ($i > 0) {
             // Skip default select option 0.
+            $args[':genus'] = $genus;
+            $args[':collection'] = $i;
 
-            $has_genus = chado_query($sql_new_collection, [':genus' => $genus, ':collection' => $i])
+            $has_genus = chado_query($sql_new_collection, $args)
               ->fetchObject();
 
             if ($has_genus && $has_genus->id > 0) {

--- a/includes/KPSEARCH.inc
+++ b/includes/KPSEARCH.inc
@@ -139,4 +139,80 @@ class KPSEARCH extends ChadoCustomSearch {
     unset($form['species']);
   }
 
+  /**
+   * Add field to allow filter based on germplasm collection
+   * or population information.
+   * 
+   * Source: stockcollection, stockcollection_stock and stock tables.
+   *
+   * @param $form
+   *   Drupal form object.
+   * @param $form_state
+   *   Drupal form state object.
+   */
+  public function addCollectionFormElement(&$form, &$form_state) {
+    $class = get_called_class();
+     
+    $default_text = '- Select -';
+    // Set default to all collection.
+    $collection_options = [0 => $default_text]; 
+    // Default to select (option 0 above array, of the field).
+    $default_collection = 0; 
+
+    // Get collections in chado.stockcollections.
+    $sql_collection = "SELECT stockcollection_id AS id, name 
+      FROM chado.stockcollection ORDER BY name ASC";
+    
+    $collections = chado_query($sql_collection);    
+    if ($collections->rowCount() > 0) {
+      foreach($collections as $collection) {
+        $collection_options[ $collection->id ] = $collection->name;
+      }
+    }
+    
+    $q = drupal_get_query_parameters();
+    
+    // Refine collection options to only collection names
+    // where registered germplasm has the genus selected.
+    if (isset($q) && is_array($q) && $collection_options) {
+      if (isset($q['genus']) && !empty($q['genus'])) {
+        $genus = $q['genus'];
+        
+        // A single stock matching the genus (from collection) would be enough
+        // to satisfy that collection has a germplasm with the genus.
+        $sql_new_collection = "
+          SELECT stock_id AS id FROM {stock} INNER JOIN {organism} USING(organism_id) 
+          WHERE organism.genus = :genus AND stock.stock_id IN 
+            (SELECT stock_id FROM {stockcollection_stock} WHERE stockcollection_id = :collection) 
+          LIMIT 1
+        ";
+        
+        // When user starts selecting filters... prepare
+        // collection field and suggest relevant to selections.
+        $new_collection_options = [0 => $default_text];
+        foreach($collection_options as $i => $collection) {
+          if ($i > 0) {
+            // Skip default select option.
+
+            $has_genus = chado_query($sql_new_collection, [':genus' => $genus, ':collection' => $i])
+              ->fetchObject();
+            
+            if ($has_genus && $has_genus > 0) {
+              $new_collection_options[ $i ] = $collection;
+            }
+          }
+        }
+      }
+    }
+
+    $options = (count($new_collection_options) > 0) ? $new_collection_options : $collection_options;
+
+    $form['collection'] = array(
+      '#type' => 'select',
+      '#title' => $class::$info['filters']['collection']['title'],
+      '#description' => $class::$info['filters']['collection']['help'],
+      '#options' => $options,
+      '#default_value' => $default_collection
+    );
+  }
 }

--- a/includes/KPSEARCH.inc
+++ b/includes/KPSEARCH.inc
@@ -198,8 +198,8 @@ class KPSEARCH extends ChadoCustomSearch {
 
             $has_genus = chado_query($sql_new_collection, [':genus' => $genus, ':collection' => $i])
               ->fetchObject();
-            
-            if ($has_genus && $has_genus > 0) {
+
+            if ($has_genus && $has_genus->id > 0) {
               $new_collection_options[ $i ] = $collection;
             }
           }
@@ -210,7 +210,10 @@ class KPSEARCH extends ChadoCustomSearch {
       $default_collection = $q['collection'];
     }
     
-    $options = (count($new_collection_options) > 1) ? $new_collection_options : $collection_options;
+    $options = (empty($genus) && count($new_collection_options) < 1) 
+      ? $collection_options : $new_collection_options;
+    
+    // Field collection render array.
     $collection_field = $class::$info['filters']['collection'];
 
     $form['collection'] = array(


### PR DESCRIPTION
This PR will add additional filter option to germplasm search particularly in main germplasm search and germplasm variety search.

![image](https://user-images.githubusercontent.com/15472253/184966277-3d04b730-f47d-4e43-97ad-26c73059e170.png)

This field is populated with all collection available in the system on load and adjusts to genus specific collection as crop is selected. The summary result table below now includes a column for collection to correspond to the collection.

To test:
1. Update kp_searches branch to pull current changes and branches.
2. Switch branch to filter-by-collection
3. Clear cache and reload search page. Filter by collection should become available for main search germplasm and search germplasm variety.





