### PR TITLE
Fixes genetic map search returning 0 result

### DIFF
--- a/includes/GeneticMapSearch.inc
+++ b/includes/GeneticMapSearch.inc
@@ -217,7 +217,7 @@ class GeneticMapSearch extends KPSEARCH {
 
     // -- Population Type.
     if ($filter_results['pop_type'] != '') {
-      $where[] = "pop_type.value ~ :pop_type";
+      $where[] = "pop_type.value = :pop_type";
       $args[':pop_type'] = $filter_results['pop_type'];
     }
 


### PR DESCRIPTION
This PR fixes 0 result returned by genetic map search of type RIL. Code changes the regular expression operator (~) to equality operator (=) of the where clause, since the options from map type is generated/fetched from table and are exact match. 

Tested on a clone